### PR TITLE
Add comment to explain why we do not let Riffraff manage stack policy in US

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -138,7 +138,6 @@ jobs:
                   cloudFormationStackByTags: false
                   prependStackToCloudFormationStackName: false
                   cloudFormationStackName: commercial-canary
-                  manageStackPolicy: false
               commercial-canary-ca:
                 type: cloud-formation
                 sources:
@@ -155,7 +154,6 @@ jobs:
                   cloudFormationStackByTags: false
                   prependStackToCloudFormationStackName: false
                   cloudFormationStackName: commercial-canary
-                  manageStackPolicy: false
               commercial-canary-us:
                 type: cloud-formation
                 sources:
@@ -172,6 +170,7 @@ jobs:
                   cloudFormationStackByTags: false
                   prependStackToCloudFormationStackName: false
                   cloudFormationStackName: commercial-canary
+                  # riffraff includes AWS::DocDB::DBCluster in the policy which is not supported in US region, so this will fail if manageStackPolicy: true
                   manageStackPolicy: false
               commercial-canary-aus:
                 type: cloud-formation
@@ -189,4 +188,3 @@ jobs:
                   cloudFormationStackByTags: false
                   prependStackToCloudFormationStackName: false
                   cloudFormationStackName: commercial-canary
-                  manageStackPolicy: false


### PR DESCRIPTION
## What does this change?

- Let Riffraff manage the [stack policy](https://riffraff.gutools.co.uk/docs/magenta-lib/types#cloudformation) for all regions except for US
- Adds a comment to explain why we set manageStackPolicy to false in the US in our riffraff template

## Explanation

If we set manageStackPolicy to true in our riffraff template, we get the following error:
`Error validating stack policy: Unknown resource type 'AWS::DocDB::DBCluster'`
This is because Amazon DocumentDB is not supported in the us-east-1 region. You can see the stack policy that Riffraff manages for us [here](https://riffraff.gutools.co.uk/docs/magenta-lib/types#cloudformation). We would prefer to allow Riffraff to manage our stack policy, but this is currently impossible in the us-east-1 region.

