### PR TITLE
Test if adding a timeout helps the CMP work in aus

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -143,6 +143,8 @@ const checkPage = async (pageType, url) => {
 	// Test 2: Adverts load and that the CMP is NOT displayed following interaction with the CMP
 	await interactWithCMP(page);
 	await checkCMPIsNotVisible(page);
+	await page.waitForTimeout(5000);
+	
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,


### PR DESCRIPTION
This is a test to verify if the CMP isn't persisting the user choice because we reload the page too quickly after clicking 'continue'.