### PR TITLE
Adding a delay after clicking 'continue'

### DIFF
--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -143,6 +143,10 @@ const checkPage = async (pageType, url) => {
 	// Test 2: Adverts load and that the CMP is NOT displayed following interaction with the CMP
 	await interactWithCMP(page);
 	await checkCMPIsNotVisible(page);
+	
+	//Some delay seems to be required before SP will persist the user's choice.
+	await page.waitForTimeout(5000);
+	
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,


### PR DESCRIPTION
Since Wednesday ~14:00 we've had failures in US and Aus. It appears that SP needs more to persist the user's choice and reloading the page too quickly after clicking 'continue' means the choice hasn't been saved. This change introduces a 5 second delay before reloading the page.

A corresponding change has already been made to the aus script.
