### PR TITLE
Update to wait behaviour

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -48,6 +48,10 @@ const interactWithCMP = async (page) => {
 		.frames()
 		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));
 	await frame.click('button[title="Continue"]');
+	/*
+	 As of Sep 14, some delay seems to be required before SP will persist the user's choice.
+	 */
+	await page.waitForTimeout(1500);
 };
 
 const checkCMPIsOnPage = async (page) => {
@@ -143,8 +147,7 @@ const checkPage = async (pageType, url) => {
 	// Test 2: Adverts load and that the CMP is NOT displayed following interaction with the CMP
 	await interactWithCMP(page);
 	await checkCMPIsNotVisible(page);
-	await page.waitForTimeout(5000);
-	
+
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -48,6 +48,10 @@ const interactWithCMP = async (page) => {
 		.frames()
 		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));
 	await frame.click('button[title="Do not sell my personal information"]');
+	/*
+	 As of Sep 14, some delay seems to be required before SP will persist the user's choice.
+	 */
+	await page.waitForTimeout(1500);
 };
 
 const checkCMPIsOnPage = async (page) => {
@@ -143,10 +147,7 @@ const checkPage = async (pageType, url) => {
 	// Test 2: Adverts load and that the CMP is NOT displayed following interaction with the CMP
 	await interactWithCMP(page);
 	await checkCMPIsNotVisible(page);
-	
-	//Some delay seems to be required before SP will persist the user's choice.
-	await page.waitForTimeout(5000);
-	
+
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,7 +1427,7 @@ table@^6.0.9:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tar-fs@*:
+tar-fs@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.1.tgz#489a15ab85f1f0befabb370b7de4f9eb5cbe8784"
   integrity sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==


### PR DESCRIPTION
Follow on from https://github.com/guardian/commercial-canaries/pull/33 and https://github.com/guardian/commercial-canaries/pull/32 which added a 5 second delay after interacting with the CMP to allow SP to save the change.

> Since Wednesday ~14:00 we've had failures in US and Aus. It appears that SP needs more to persist the user's choice and reloading the page too quickly after clicking 'continue' means the choice hasn't been saved. This change introduces a 5 second delay before reloading the page.

This change moves the delay from the script part of the file to the `interactWithCMP` function itself (where it belongs).
This also reduces the 5 send delay to 1.5s because SP has assured us it doesn't take that long to persist the change.
