### PR TITLE
Doml/update accept button for ab test

### DIFF
--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -52,7 +52,7 @@ Object {
           "MemoryInMB": 3008,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.7",
         "Schedule": Object {
           "DurationInSeconds": "1800",
           "Expression": "rate(1 minute)",
@@ -303,7 +303,7 @@ Object {
           "MemoryInMB": 3008,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.7",
         "Schedule": Object {
           "DurationInSeconds": "0",
           "Expression": "rate(1 minute)",
@@ -554,7 +554,7 @@ Object {
           "MemoryInMB": 2048,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.7",
         "Schedule": Object {
           "DurationInSeconds": "1800",
           "Expression": "rate(1 minute)",
@@ -805,7 +805,7 @@ Object {
           "MemoryInMB": 2048,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.7",
         "Schedule": Object {
           "DurationInSeconds": "0",
           "Expression": "rate(1 minute)",
@@ -1056,7 +1056,7 @@ Object {
           "MemoryInMB": 2048,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.7",
         "Schedule": Object {
           "DurationInSeconds": "1800",
           "Expression": "rate(1 minute)",
@@ -1307,7 +1307,7 @@ Object {
           "MemoryInMB": 2048,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.7",
         "Schedule": Object {
           "DurationInSeconds": "0",
           "Expression": "rate(1 minute)",
@@ -1558,7 +1558,7 @@ Object {
           "MemoryInMB": 3008,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.7",
         "Schedule": Object {
           "DurationInSeconds": "1800",
           "Expression": "rate(1 minute)",
@@ -1809,7 +1809,7 @@ Object {
           "MemoryInMB": 3008,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.6",
+        "RuntimeVersion": "syn-nodejs-puppeteer-3.7",
         "Schedule": Object {
           "DurationInSeconds": "0",
           "Expression": "rate(1 minute)",

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -121,7 +121,7 @@ export class CommercialCanaries extends GuStack {
 			},
 			executionRoleArn: role.roleArn,
 			name: canaryName,
-			runtimeVersion: 'syn-nodejs-puppeteer-3.6',
+			runtimeVersion: 'syn-nodejs-puppeteer-3.7',
 			runConfig: {
 				timeoutInSeconds: 60,
 				memoryInMb: isTcf ? 2048 : 3008,

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -48,6 +48,7 @@ const interactWithCMP = async (page) => {
 		.frames()
 		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));
 	await frame.click('button[title="Continue"]');
+
 	/*
 	 As of Sep 14, some delay seems to be required before SP will persist the user's choice.
 	 */

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -48,6 +48,7 @@ const interactWithCMP = async (page) => {
 		.frames()
 		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));
 	await frame.click('button[title="Do not sell my personal information"]');
+
 	/*
 	 As of Sep 14, some delay seems to be required before SP will persist the user's choice.
 	 */

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -63,7 +63,7 @@ const interactWithCMP = async (page) => {
 		.frames()
 		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));
 
-	await frame.click('div.message-row > button.btn-primary');
+	await frame.click('div.message-row > button.btn-primary.sp_choice_type_11');
 };
 
 const checkCMPIsOnPage = async (page) => {

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -63,7 +63,8 @@ const interactWithCMP = async (page) => {
 		.frames()
 		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));
 
-	await frame.click('div.message-row > button.btn-primary.sp_choice_type_11');
+	// Accept cookies
+	await frame.click('div.message-component.message-row > button.btn-primary.sp_choice_type_11');
 };
 
 const checkCMPIsOnPage = async (page) => {

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -62,7 +62,8 @@ const interactWithCMP = async (page) => {
 	const frame = page
 		.frames()
 		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));
-	await frame.click('button[title="Yes, I’m happy"]');
+
+	await frame.click('div.message-row > button.btn-primary');
 };
 
 const checkCMPIsOnPage = async (page) => {


### PR DESCRIPTION
## What does this change?

- Update the selector for finding the Accept Cookies button in the SourcePoint iframe. It now uses classes on the button and the containing div to identify the correct button, instead of the text in the button. This is because the text is more likely to change than the css classes.
- Updates runtime to `syn-nodejs-puppeteer-3.7`.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Why?

We are running an AB test which involves altering the text of the Accept Cookies button in the SourcePoint cookie banner. This is causing the canaries to fail when the browser is included in the AB test and the button text has changed.

## How to test

Check that a run passes using a test canary.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

No more failures.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
