### PR TITLE
cd: Remove Riff-Raff configuration workaround

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -170,8 +170,6 @@ jobs:
                   cloudFormationStackByTags: false
                   prependStackToCloudFormationStackName: false
                   cloudFormationStackName: commercial-canary
-                  # riffraff includes AWS::DocDB::DBCluster in the policy which is not supported in US region, so this will fail if manageStackPolicy: true
-                  manageStackPolicy: false
               commercial-canary-aus:
                 type: cloud-formation
                 sources:


### PR DESCRIPTION
## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Riff-Raff offers some protection for stateful resources during a CloudFormation deployment, however there was a bug when this is performed in the us-west-1 region, and we've opted out by setting `manageStackPolicy` to `false`. https://github.com/guardian/riff-raff/pull/874 patches Riff-Raff, removing the need for this workaround. See the Riff-Raff PR for more detail.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Deploy https://github.com/guardian/riff-raff/pull/874 to Riff-Raff CODE
- Deploy this branch to CODE
- Observe Riff-Raff performing a CloudFormation deployment in the us-west-1 region, without error

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

More protection from Riff-Raff, and no more [scary messages](https://github.com/guardian/riff-raff/pull/872) in the build log!

### Before ([deployed via Riff-Raff PROD](https://riffraff.gutools.co.uk/deployment/view/adc82543-f29d-4a1b-ad13-1723fc45cafd))
![image](https://user-images.githubusercontent.com/836140/194273558-eaca1eb6-de6f-4b6f-be53-0e30dc84faff.png)


### After ([deployed via https://github.com/guardian/riff-raff/pull/874 on Riff-Raff CODE](https://riffraff.code.dev-gutools.co.uk/deployment/view/b68d25cc-3e57-492c-9f59-9e4866dec926?verbose=0))
![image](https://user-images.githubusercontent.com/836140/194274885-cddc33f2-ad65-434c-b613-ebc31132cd64.png)