### PR TITLE
Allow canary to delete objects from the results s3 bucket

### DIFF
--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -133,6 +133,7 @@ Object {
                     "s3:PutObject",
                     "s3:GetObject",
                     "s3:GetBucketLocation",
+                    "s3:DeleteObject",
                   ],
                   "Effect": "Allow",
                   "Resource": Object {
@@ -384,6 +385,7 @@ Object {
                     "s3:PutObject",
                     "s3:GetObject",
                     "s3:GetBucketLocation",
+                    "s3:DeleteObject",
                   ],
                   "Effect": "Allow",
                   "Resource": Object {
@@ -635,6 +637,7 @@ Object {
                     "s3:PutObject",
                     "s3:GetObject",
                     "s3:GetBucketLocation",
+                    "s3:DeleteObject",
                   ],
                   "Effect": "Allow",
                   "Resource": Object {
@@ -886,6 +889,7 @@ Object {
                     "s3:PutObject",
                     "s3:GetObject",
                     "s3:GetBucketLocation",
+                    "s3:DeleteObject",
                   ],
                   "Effect": "Allow",
                   "Resource": Object {
@@ -1137,6 +1141,7 @@ Object {
                     "s3:PutObject",
                     "s3:GetObject",
                     "s3:GetBucketLocation",
+                    "s3:DeleteObject",
                   ],
                   "Effect": "Allow",
                   "Resource": Object {
@@ -1388,6 +1393,7 @@ Object {
                     "s3:PutObject",
                     "s3:GetObject",
                     "s3:GetBucketLocation",
+                    "s3:DeleteObject",
                   ],
                   "Effect": "Allow",
                   "Resource": Object {
@@ -1639,6 +1645,7 @@ Object {
                     "s3:PutObject",
                     "s3:GetObject",
                     "s3:GetBucketLocation",
+                    "s3:DeleteObject",
                   ],
                   "Effect": "Allow",
                   "Resource": Object {
@@ -1890,6 +1897,7 @@ Object {
                     "s3:PutObject",
                     "s3:GetObject",
                     "s3:GetBucketLocation",
+                    "s3:DeleteObject",
                   ],
                   "Effect": "Allow",
                   "Resource": Object {

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -64,7 +64,7 @@ export class CommercialCanaries extends GuStack {
 				}),
 				new iam.PolicyStatement({
 					resources: [`arn:aws:s3:::${S3BucketResults}/*`],
-					actions: ['s3:PutObject', 's3:GetObject', 's3:GetBucketLocation'],
+					actions: ['s3:PutObject', 's3:GetObject', 's3:GetBucketLocation', 's3:DeleteObject'],
 					effect: iam.Effect.ALLOW,
 				}),
 				new iam.PolicyStatement({

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -64,7 +64,12 @@ export class CommercialCanaries extends GuStack {
 				}),
 				new iam.PolicyStatement({
 					resources: [`arn:aws:s3:::${S3BucketResults}/*`],
-					actions: ['s3:PutObject', 's3:GetObject', 's3:GetBucketLocation', 's3:DeleteObject'],
+					actions: [
+						's3:PutObject',
+						's3:GetObject',
+						's3:GetBucketLocation',
+						's3:DeleteObject',
+					],
 					effect: iam.Effect.ALLOW,
 				}),
 				new iam.PolicyStatement({


### PR DESCRIPTION
## What does this change?
Adds `s3:DeleteObject` to the canary IAM role, this is just a hunch because I can't see any signs of the canary complaining about this, but is certainly a barrier.

It's already set up to delete old results with the `successRetentionPeriod` and `failureRetentionPeriod` attributes.

This should solve the problem of the retention rules not being obeyed, and reports piling up in s3 and starting to take up ~7TB or 12% of all storage...

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
