### PR TITLE
Reduce the timeouts on action for CCPA

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -52,7 +52,7 @@ const interactWithCMP = async (page) => {
 	/*
 	 As of Sep 14, some delay seems to be required before SP will persist the user's choice.
 	 */
-	await page.waitForTimeout(1500);
+	await page.waitForTimeout(500);
 };
 
 const checkCMPIsOnPage = async (page) => {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -52,7 +52,7 @@ const interactWithCMP = async (page) => {
 	/*
 	 As of Sep 14, some delay seems to be required before SP will persist the user's choice.
 	 */
-	await page.waitForTimeout(1500);
+	await page.waitForTimeout(500);
 };
 
 const checkCMPIsOnPage = async (page) => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
In september a change was introduced by SP that required us to add a delay after interacting with the CMP to allow SP to persist the change. The delay was added here: https://github.com/guardian/commercial-canaries/pull/32

Since then the change seems to be 'saved' faster and such a long timeout should no longer be required.

