### PR TITLE
Insignificant changes to force redeploy

### DIFF
--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -50,7 +50,7 @@ Object {
             "Arn",
           ],
         },
-        "FailureRetentionPeriod": 30,
+        "FailureRetentionPeriod": 31,
         "Name": "comm_cmp_canary_code",
         "RunConfig": Object {
           "MemoryInMB": 3008,
@@ -306,7 +306,7 @@ Object {
             "Arn",
           ],
         },
-        "FailureRetentionPeriod": 30,
+        "FailureRetentionPeriod": 31,
         "Name": "comm_cmp_canary_prod",
         "RunConfig": Object {
           "MemoryInMB": 3008,
@@ -562,7 +562,7 @@ Object {
             "Arn",
           ],
         },
-        "FailureRetentionPeriod": 30,
+        "FailureRetentionPeriod": 31,
         "Name": "comm_cmp_canary_code",
         "RunConfig": Object {
           "MemoryInMB": 2048,
@@ -818,7 +818,7 @@ Object {
             "Arn",
           ],
         },
-        "FailureRetentionPeriod": 30,
+        "FailureRetentionPeriod": 31,
         "Name": "comm_cmp_canary_prod",
         "RunConfig": Object {
           "MemoryInMB": 2048,
@@ -1074,7 +1074,7 @@ Object {
             "Arn",
           ],
         },
-        "FailureRetentionPeriod": 30,
+        "FailureRetentionPeriod": 31,
         "Name": "comm_cmp_canary_code",
         "RunConfig": Object {
           "MemoryInMB": 2048,
@@ -1330,7 +1330,7 @@ Object {
             "Arn",
           ],
         },
-        "FailureRetentionPeriod": 30,
+        "FailureRetentionPeriod": 31,
         "Name": "comm_cmp_canary_prod",
         "RunConfig": Object {
           "MemoryInMB": 2048,
@@ -1586,7 +1586,7 @@ Object {
             "Arn",
           ],
         },
-        "FailureRetentionPeriod": 30,
+        "FailureRetentionPeriod": 31,
         "Name": "comm_cmp_canary_code",
         "RunConfig": Object {
           "MemoryInMB": 3008,
@@ -1842,7 +1842,7 @@ Object {
             "Arn",
           ],
         },
-        "FailureRetentionPeriod": 30,
+        "FailureRetentionPeriod": 31,
         "Name": "comm_cmp_canary_prod",
         "RunConfig": Object {
           "MemoryInMB": 3008,

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -137,7 +137,7 @@ export class CommercialCanaries extends GuStack {
 			},
 			deleteLambdaResourcesOnCanaryDeletion: true,
 			successRetentionPeriod: 7,
-			failureRetentionPeriod: 30,
+			failureRetentionPeriod: 31,
 			startCanaryAfterCreation: true,
 			tags: [
 				{

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -58,7 +58,7 @@ const checkTopAdDidNotLoad = async (page) => {
 
 const interactWithCMP = async (page) => {
 	// When AWS Synthetics use a more up-to-date version of Puppeteer, we can make use of waitForFrame()
-	log(`Clicking on "Yes I'm Happy" on CMP`);
+	log(`Clicking on "Yes I'm Happy"`);
 	const frame = page
 		.frames()
 		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));


### PR DESCRIPTION
I'm making changes to both the CDK stack and the lambda in an attempt to force both to rebuild and redeploy.
The changes themselves are not significant but:
 - The failure retention period is increased from 30 to 31 days
 - The log message on clicking "Yes I'm Happy" changes from `Clicking on "Yes I'm Happy" on CMP` to `Clicking on "Yes I'm Happy"`