### PR TITLE
Bump synthetics version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ From here, you can see all the details relating to the canary and the recent run
 
 ## Requirements
 
--   [Node 14](https://nodejs.org/en/download/) ([nvm](https://github.com/nvm-sh/nvm))
 -   [Yarn](https://classic.yarnpkg.com/en/docs/install/)
 
 ## Development

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -56,7 +56,7 @@ Object {
           "MemoryInMB": 3008,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.9",
+        "RuntimeVersion": "syn-nodejs-puppeteer-4.0",
         "Schedule": Object {
           "DurationInSeconds": "1800",
           "Expression": "rate(1 minute)",
@@ -312,7 +312,7 @@ Object {
           "MemoryInMB": 3008,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.9",
+        "RuntimeVersion": "syn-nodejs-puppeteer-4.0",
         "Schedule": Object {
           "DurationInSeconds": "0",
           "Expression": "rate(1 minute)",
@@ -568,7 +568,7 @@ Object {
           "MemoryInMB": 2048,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.9",
+        "RuntimeVersion": "syn-nodejs-puppeteer-4.0",
         "Schedule": Object {
           "DurationInSeconds": "1800",
           "Expression": "rate(1 minute)",
@@ -824,7 +824,7 @@ Object {
           "MemoryInMB": 2048,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.9",
+        "RuntimeVersion": "syn-nodejs-puppeteer-4.0",
         "Schedule": Object {
           "DurationInSeconds": "0",
           "Expression": "rate(1 minute)",
@@ -1080,7 +1080,7 @@ Object {
           "MemoryInMB": 2048,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.9",
+        "RuntimeVersion": "syn-nodejs-puppeteer-4.0",
         "Schedule": Object {
           "DurationInSeconds": "1800",
           "Expression": "rate(1 minute)",
@@ -1336,7 +1336,7 @@ Object {
           "MemoryInMB": 2048,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.9",
+        "RuntimeVersion": "syn-nodejs-puppeteer-4.0",
         "Schedule": Object {
           "DurationInSeconds": "0",
           "Expression": "rate(1 minute)",
@@ -1592,7 +1592,7 @@ Object {
           "MemoryInMB": 3008,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.9",
+        "RuntimeVersion": "syn-nodejs-puppeteer-4.0",
         "Schedule": Object {
           "DurationInSeconds": "1800",
           "Expression": "rate(1 minute)",
@@ -1848,7 +1848,7 @@ Object {
           "MemoryInMB": 3008,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-3.9",
+        "RuntimeVersion": "syn-nodejs-puppeteer-4.0",
         "Schedule": Object {
           "DurationInSeconds": "0",
           "Expression": "rate(1 minute)",

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -126,7 +126,7 @@ export class CommercialCanaries extends GuStack {
 			},
 			executionRoleArn: role.roleArn,
 			name: canaryName,
-			runtimeVersion: 'syn-nodejs-puppeteer-3.9',
+			runtimeVersion: 'syn-nodejs-puppeteer-4.0',
 			runConfig: {
 				timeoutInSeconds: 60,
 				memoryInMb: isTcf ? 2048 : 3008,


### PR DESCRIPTION
## What does this change?

- Update synthetics version to 4.0.
- Remove Node 14 advice from README.

## How to test

Log in the the AWS console and check that the canaries are still working.
