### PR TITLE
Remove step to ask comdev for access to release diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ A push to the main branch will trigger the Github Action `deploy.yaml`, which ru
 
 ### Further information
 
-Diagram [here](https://docs.google.com/presentation/d/1l8QFoq7siUWdJMRq_qc8vLcNf1iFhXH5aKx3Ok5xEu4/edit#slide=id.gb8f2b491c7_0_44) - ask commercial if you need access to it.
+Diagram [here](https://docs.google.com/presentation/d/1l8QFoq7siUWdJMRq_qc8vLcNf1iFhXH5aKx3Ok5xEu4/edit#slide=id.gb8f2b491c7_0_44)


### PR DESCRIPTION
## What does this change?

- Update README to remove step to ask comdev for access to release diagram

## Have we considered potential risks?

There is no need for this deck to be locked down to comdev. We have updated the permissions to give everyone in the Guardian access

