### PR TITLE
Remove waitForTimeout in Aus interactWithCMP

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -48,11 +48,6 @@ const interactWithCMP = async (page) => {
 		.frames()
 		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));
 	await frame.click('button[title="Continue"]');
-
-	/*
-	 As of Sep 14, some delay seems to be required before SP will persist the user's choice.
-	 */
-	await page.waitForTimeout(500);
 };
 
 const checkCMPIsOnPage = async (page) => {


### PR DESCRIPTION
## What does this change?

We're investigating whether or not there is a delay in persisting the user's consent choice in SourcePoint in Australia. This time delay was originally added to prevent canary failures, due to the delay in the consent choice being persisted.

We believe the issue with the consent choice being delayed should be fixed, so we'd like to verify this by removing the waitForTimeout in the interactWithCMP function in Australia. At the moment, T&C's monitoring is out of action, so it makes sense for us to test this here.

## How can we measure success?

If the canary begins to fail, then we'll know that this delay still exists. If the canary still passes, then we'll know that the consent choice delay issue has been resolved.

