### PR TITLE
use buildId instead of lambdaSHA

### DIFF
--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -7,7 +7,7 @@ Object {
     "gu:cdk:version": "TEST",
   },
   "Parameters": Object {
-    "lambdaCodeSha": Object {
+    "BuildId": Object {
       "Description": "The SHA of the lambda code files.",
       "Type": "String",
     },
@@ -65,18 +65,18 @@ Object {
         "SuccessRetentionPeriod": 7,
         "Tags": Array [
           Object {
+            "Key": "BuildId",
+            "Value": Object {
+              "Ref": "BuildId",
+            },
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
           Object {
             "Key": "gu:repo",
             "Value": "guardian/commercial-canaries",
-          },
-          Object {
-            "Key": "Lambda code SHA",
-            "Value": Object {
-              "Ref": "lambdaCodeSha",
-            },
           },
           Object {
             "Key": "Stack",
@@ -230,7 +230,7 @@ Object {
     "gu:cdk:version": "TEST",
   },
   "Parameters": Object {
-    "lambdaCodeSha": Object {
+    "BuildId": Object {
       "Description": "The SHA of the lambda code files.",
       "Type": "String",
     },
@@ -321,18 +321,18 @@ Object {
         "SuccessRetentionPeriod": 7,
         "Tags": Array [
           Object {
+            "Key": "BuildId",
+            "Value": Object {
+              "Ref": "BuildId",
+            },
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
           Object {
             "Key": "gu:repo",
             "Value": "guardian/commercial-canaries",
-          },
-          Object {
-            "Key": "Lambda code SHA",
-            "Value": Object {
-              "Ref": "lambdaCodeSha",
-            },
           },
           Object {
             "Key": "Stack",
@@ -519,7 +519,7 @@ Object {
     "gu:cdk:version": "TEST",
   },
   "Parameters": Object {
-    "lambdaCodeSha": Object {
+    "BuildId": Object {
       "Description": "The SHA of the lambda code files.",
       "Type": "String",
     },
@@ -577,18 +577,18 @@ Object {
         "SuccessRetentionPeriod": 7,
         "Tags": Array [
           Object {
+            "Key": "BuildId",
+            "Value": Object {
+              "Ref": "BuildId",
+            },
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
           Object {
             "Key": "gu:repo",
             "Value": "guardian/commercial-canaries",
-          },
-          Object {
-            "Key": "Lambda code SHA",
-            "Value": Object {
-              "Ref": "lambdaCodeSha",
-            },
           },
           Object {
             "Key": "Stack",
@@ -742,7 +742,7 @@ Object {
     "gu:cdk:version": "TEST",
   },
   "Parameters": Object {
-    "lambdaCodeSha": Object {
+    "BuildId": Object {
       "Description": "The SHA of the lambda code files.",
       "Type": "String",
     },
@@ -833,18 +833,18 @@ Object {
         "SuccessRetentionPeriod": 7,
         "Tags": Array [
           Object {
+            "Key": "BuildId",
+            "Value": Object {
+              "Ref": "BuildId",
+            },
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
           Object {
             "Key": "gu:repo",
             "Value": "guardian/commercial-canaries",
-          },
-          Object {
-            "Key": "Lambda code SHA",
-            "Value": Object {
-              "Ref": "lambdaCodeSha",
-            },
           },
           Object {
             "Key": "Stack",
@@ -1031,7 +1031,7 @@ Object {
     "gu:cdk:version": "TEST",
   },
   "Parameters": Object {
-    "lambdaCodeSha": Object {
+    "BuildId": Object {
       "Description": "The SHA of the lambda code files.",
       "Type": "String",
     },
@@ -1089,18 +1089,18 @@ Object {
         "SuccessRetentionPeriod": 7,
         "Tags": Array [
           Object {
+            "Key": "BuildId",
+            "Value": Object {
+              "Ref": "BuildId",
+            },
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
           Object {
             "Key": "gu:repo",
             "Value": "guardian/commercial-canaries",
-          },
-          Object {
-            "Key": "Lambda code SHA",
-            "Value": Object {
-              "Ref": "lambdaCodeSha",
-            },
           },
           Object {
             "Key": "Stack",
@@ -1254,7 +1254,7 @@ Object {
     "gu:cdk:version": "TEST",
   },
   "Parameters": Object {
-    "lambdaCodeSha": Object {
+    "BuildId": Object {
       "Description": "The SHA of the lambda code files.",
       "Type": "String",
     },
@@ -1345,18 +1345,18 @@ Object {
         "SuccessRetentionPeriod": 7,
         "Tags": Array [
           Object {
+            "Key": "BuildId",
+            "Value": Object {
+              "Ref": "BuildId",
+            },
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
           Object {
             "Key": "gu:repo",
             "Value": "guardian/commercial-canaries",
-          },
-          Object {
-            "Key": "Lambda code SHA",
-            "Value": Object {
-              "Ref": "lambdaCodeSha",
-            },
           },
           Object {
             "Key": "Stack",
@@ -1543,7 +1543,7 @@ Object {
     "gu:cdk:version": "TEST",
   },
   "Parameters": Object {
-    "lambdaCodeSha": Object {
+    "BuildId": Object {
       "Description": "The SHA of the lambda code files.",
       "Type": "String",
     },
@@ -1601,18 +1601,18 @@ Object {
         "SuccessRetentionPeriod": 7,
         "Tags": Array [
           Object {
+            "Key": "BuildId",
+            "Value": Object {
+              "Ref": "BuildId",
+            },
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
           Object {
             "Key": "gu:repo",
             "Value": "guardian/commercial-canaries",
-          },
-          Object {
-            "Key": "Lambda code SHA",
-            "Value": Object {
-              "Ref": "lambdaCodeSha",
-            },
           },
           Object {
             "Key": "Stack",
@@ -1766,7 +1766,7 @@ Object {
     "gu:cdk:version": "TEST",
   },
   "Parameters": Object {
-    "lambdaCodeSha": Object {
+    "BuildId": Object {
       "Description": "The SHA of the lambda code files.",
       "Type": "String",
     },
@@ -1857,18 +1857,18 @@ Object {
         "SuccessRetentionPeriod": 7,
         "Tags": Array [
           Object {
+            "Key": "BuildId",
+            "Value": Object {
+              "Ref": "BuildId",
+            },
+          },
+          Object {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },
           Object {
             "Key": "gu:repo",
             "Value": "guardian/commercial-canaries",
-          },
-          Object {
-            "Key": "Lambda code SHA",
-            "Value": Object {
-              "Ref": "lambdaCodeSha",
-            },
           },
           Object {
             "Key": "Stack",

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -50,7 +50,7 @@ export class CommercialCanaries extends GuStack {
 		 *    will be different, which will trigger the CloudFormation stack to update the
 		 *    lambda code used by the canary.
 		 */
-		const lambdaCodeSha = new CfnParameter(this, 'lambdaCodeSha', {
+		const buildId = new CfnParameter(this, 'BuildId', {
 			type: 'String',
 			description: 'The SHA of the lambda code files.',
 		});
@@ -141,8 +141,8 @@ export class CommercialCanaries extends GuStack {
 			startCanaryAfterCreation: true,
 			tags: [
 				{
-					key: 'Lambda code SHA',
-					value: lambdaCodeSha.valueAsString,
+					key: 'BuildId',
+					value: buildId.valueAsString,
 				},
 			],
 		});


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
