### PR TITLE
Handle page reload after consent change for CCPA canary

### DIFF
--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -151,7 +151,7 @@ const loadPage = async (page, url) => {
 };
 
 // We need to wait for the page to finish reloading following a consent state change
-const waitForPageRefresh = async(page) => {
+const waitForPageReload = async(page) => {
 	page.waitForLoadState('domcontentloaded');
 
 	// We see some run failures if we do not include a wait time after a page load
@@ -183,7 +183,7 @@ const checkPage = async (pageType, url) => {
 
 	// Test 2: Adverts load and the CMP is NOT displayed following interaction with the CMP
 	await interactWithCMP(page);
-	await waitForPageRefresh(page);
+	await waitForPageReload(page);
 	await checkCMPIsNotVisible(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -152,7 +152,7 @@ const loadPage = async (page, url) => {
 
 // We need to wait for the page to finish reloading following a consent state change
 const waitForPageReload = async(page) => {
-	page.waitForLoadState('domcontentloaded');
+	await page.waitForNavigation({waitUntil: 'domcontentloaded'});
 
 	// We see some run failures if we do not include a wait time after a page load
 	await page.waitForTimeout(3000);

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -48,11 +48,6 @@ const interactWithCMP = async (page) => {
 		.frames()
 		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));
 	await frame.click('button[title="Do not sell my personal information"]');
-
-	/*
-	 As of Sep 14, some delay seems to be required before SP will persist the user's choice.
-	 */
-	await page.waitForTimeout(500);
 };
 
 const checkCMPIsOnPage = async (page) => {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -48,6 +48,10 @@ const interactWithCMP = async (page) => {
 		.frames()
 		.find((f) => f.url().startsWith('https://sourcepoint.theguardian.com'));
 	await frame.click('button[title="Do not sell my personal information"]');
+
+	await page.waitForNavigation({waitUntil: 'domcontentloaded'});
+	// We see some run failures if we do not include a wait time after a page load
+	await page.waitForTimeout(3000);
 };
 
 const checkCMPIsOnPage = async (page) => {
@@ -145,14 +149,6 @@ const loadPage = async (page, url) => {
 	log(`Loading page: Complete`);
 };
 
-// We need to wait for the page to finish reloading following a consent state change
-const waitForPageReload = async(page) => {
-	await page.waitForNavigation({waitUntil: 'domcontentloaded'});
-
-	// We see some run failures if we do not include a wait time after a page load
-	await page.waitForTimeout(3000);
-}
-
 /**
  * Checks that ads load correctly for the first time a user goes to
  * the site, with respect to and interaction with the CMP.
@@ -178,7 +174,6 @@ const checkPage = async (pageType, url) => {
 
 	// Test 2: Adverts load and the CMP is NOT displayed following interaction with the CMP
 	await interactWithCMP(page);
-	await waitForPageReload(page);
 	await checkCMPIsNotVisible(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -150,6 +150,14 @@ const loadPage = async (page, url) => {
 	log(`Loading page: Complete`);
 };
 
+// We need to wait for the page to finish reloading following a consent state change
+const waitForPageRefresh = async(page) => {
+	page.waitForLoadState('domcontentloaded');
+
+	// We see some run failures if we do not include a wait time after a page load
+	await page.waitForTimeout(3000);
+}
+
 /**
  * Checks that ads load correctly for the first time a user goes to
  * the site, with respect to and interaction with the CMP.
@@ -175,14 +183,12 @@ const checkPage = async (pageType, url) => {
 
 	// Test 2: Adverts load and the CMP is NOT displayed following interaction with the CMP
 	await interactWithCMP(page);
+	await waitForPageRefresh(page);
 	await checkCMPIsNotVisible(page);
-
-	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'CMP clicked then page reloaded',
 	);
-	await checkCMPIsNotVisible(page);
 	await checkTopAdHasLoaded(page);
 
 	// Test 3: After we clear local storage and cookies, the CMP banner is displayed once again


### PR DESCRIPTION
## What does this change?
Waits for the page to reload after clicking "Do not sell my personal information" before trying to inspect the DOM. We currently have a timeout after clicking this, which I believe is why the canary is still managing to pass sometimes as there can be just enough time for the page to reload before checking that the CMP isn't visible. This change handles that wait explicitly.

I've tested this on CODE and it looks pretty stable:
<img width="801" alt="Screenshot 2024-03-08 at 11 44 22" src="https://github.com/guardian/commercial-canaries/assets/108270776/539a648e-d406-4558-9b90-46a40e99c2ad">

