### PR TITLE
adds canaries checks for new prebid tests

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -170,9 +170,7 @@ const checkPrebid = async (page) => {
 
 	if (bidResponses) {
 		log(
-			`[TEST 4: BID RESPONSE] Bid Response for top-above-nav complete: ${JSON.stringify(
-				bidResponses,
-			)}`,
+			`[TEST 4: BID RESPONSE] Bid Response for top-above-nav complete`,
 		);
 	} else {
 		logError(
@@ -222,7 +220,9 @@ const checkPage = async (pageType, url) => {
 	await clearCookies(page);
 
 	// Now we can run our tests.
-	log(`[TEST 1] start: CMP loads and the ads are NOT displayed on initial load`);
+	log(
+		`[TEST 1] start: CMP loads and the ads are NOT displayed on initial load`,
+	);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkCMPIsOnPage(page);

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -150,23 +150,75 @@ const checkPrebid = async (page) => {
 
 	// --------------- BID RESPONSE START ---------------------------
 	log(`[TEST 4: BID RESPONSE] Step start`);
-	const bidResponses = await page.waitForFunction(() => {
-		if (window.pbjs) {
-			return pbjs.getBidResponses()['dfp-ad--top-above-nav'];
-		} else {
-			return null;
-		}
+
+	await page.waitForFunction(
+		() => {
+			const events = window.pbjs?.getEvents() ?? [];
+			return events.find(
+				(event) =>
+					event.eventType === 'auctionInit' &&
+					event.args.adUnitCodes.includes('dfp-ad--top-above-nav'),
+			);
+		},
+		{ timeout: 10000 },
+	);
+
+	const topAboveNavBidderRequests = await page.evaluate(() => {
+		const auctionInitEvent = window.pbjs
+			?.getEvents()
+			.find(
+				(event) =>
+					event.eventType === 'auctionInit' &&
+					event.args.adUnitCodes.includes('dfp-ad--top-above-nav'),
+			);
+
+		return auctionInitEvent?.args.bidderRequests || [];
 	});
 
-	if (bidResponses) {
+	const expectedBidders = [
+		'ix',
+		'rubicon',
+		'criteo',
+		'pubmatic',
+		'ttd',
+		'adyoulike',
+		'triplelift',
+		'and',
+		'oxd',
+	];
+
+	if (topAboveNavBidderRequests.length === 0) {
 		log(
-			`[TEST 4: BID RESPONSE] Bid Response for top-above-nav complete`,
-		);
-	} else {
-		logError(
 			'[TEST 4: BID RESPONSE] Bid Response for top-above-nav is null or pbjs is not defined',
 		);
 	}
+	if (topAboveNavBidderRequests.length !== expectedBidders.length) {
+		log(
+			`[TEST 4: BID RESPONSE] Expected ${expectedBidders.length} bidders, got ${topAboveNavBidderRequests.length}`,
+		);
+	}
+
+	const theActualBidders = topAboveNavBidderRequests.map(
+		(bidder) => bidder.bidderCode,
+	);
+	log(
+		`[TEST 4: BID RESPONSE] Actual Bidders ${JSON.stringify(theActualBidders)}`,
+	);
+
+	let allMatched = true;
+
+	expectedBidders.forEach((bidder) => {
+		if (!theActualBidders.includes(bidder)) {
+			allMatched = false;
+			log(`[TEST 4: BID RESPONSE] Missing bidder: ${bidder}`);
+		}
+	});
+	if (allMatched) {
+		log(`[TEST 4: BID RESPONSE] All bidders matched`);
+	} else {
+		log(`[TEST 4: BID RESPONSE] Not all bidders matched`);
+	}
+
 	log(`[TEST 4: BID RESPONSE] Step complete`);
 	// --------------- BID RESPONSE END ---------------------------
 };
@@ -249,7 +301,6 @@ const checkPage = async (pageType, url) => {
 	log(`[TEST 4] start: Prebid`);
 	await checkPrebid(page);
 	log(`[TEST 4] completed`);
-
 };
 
 const pageLoadBlueprint = async function () {

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -140,7 +140,7 @@ const checkPrebid = async (page) => {
 
 	// --------------- PBJS START ---------------------------
 	log(`[TEST 4: PBJS] Step start`);
-	const hasPrebid = await page.evaluate(() => window.pbjs !== undefined);
+	const hasPrebid = await page.waitForFunction(() => window.pbjs !== undefined);
 	if (!hasPrebid) {
 		logError('[TEST 4: PBJS] Prebid.js is not loaded');
 		throw new Error('Prebid.js is missing');
@@ -150,7 +150,7 @@ const checkPrebid = async (page) => {
 
 	// --------------- BID RESPONSE START ---------------------------
 	log(`[TEST 4: BID RESPONSE] Step start`);
-	const bidResponses = await page.evaluate(() => {
+	const bidResponses = await page.waitForFunction(() => {
 		if (window.pbjs) {
 			return pbjs.getBidResponses()['dfp-ad--top-above-nav'];
 		} else {

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -95,31 +95,92 @@ const reloadPage = async (page) => {
 };
 
 const checkPrebid = async (page) => {
-	log(`Reloading page: Start`);
+	// --------------- RELOAD PAGE START ---------------------------
+	log(`[TEST 4: RELOAD PAGE] Step start`);
 	const reloadResponse = await page.reload({
 		waitUntil: 'domcontentloaded',
 		timeout: 30000,
 	});
 	if (!reloadResponse) {
-		logError(`Reloading page : Failed`);
+		logError(`[TEST 4: RELOAD PAGE] Reloading page : Failed`);
 		throw 'Failed to refresh page!';
 	}
-	log(`Reloading page: Complete`);
+	log(`[TEST 4: RELOAD PAGE] Step complete`);
+	// --------------- RELOAD PAGE END ---------------------------
 
+	// --------------- BUNDLE START ---------------------------
+	log(`[TEST 4: PREBID BUNDLE] Checking: graun.Prebid.js.commercial.js`);
+	await page.waitForRequest((req) =>
+		req.url().includes('graun.Prebid.js.commercial.js'),
+	);
+	log(`[TEST 4: PREBID BUNDLE] Step start`);
+	// --------------- BUNDLE END ---------------------------
+
+	// --------------- CANADA START ---------------------------
+	log(`[TEST 4: CANADA] Step start`);
+	const currentLocation = await getCurrentLocation(page);
+	if (currentLocation === 'CA') {
+		log('[TEST 4: CANADA] In Canada we do not run Prebid');
+		return Promise.resolve();
+	}
+	log(`[TEST 4: CANADA] Step complete`);
+	// --------------- CANADA END ---------------------------
+
+	// --------------- PAGESKIN START ---------------------------
+	log(`[TEST 4: PAGESKIN] Step start`);
 	const hasPageskin = await page.evaluate(() =>
 		document.body.classList.contains('has-page-skin'),
 	);
 
 	if (hasPageskin) {
-		log('Pageskin detected. Prebid will not run');
+		log('[TEST 4: PAGESKIN] Pageskin detected. Prebid will not run');
 		return Promise.resolve();
 	}
+	log(`[TEST 4: PAGESKIN] Step complete`);
+	// --------------- PAGESKIN END ---------------------------
 
+	// --------------- PUBMATIC START ---------------------------
+	log(`[TEST 4: PUBMATIC] Step start`);
 	const prebidURL =
 		'https://hbopenbid.pubmatic.com/translator?source=prebid-client';
 
 	await page.waitForRequest((req) => req.url().includes(prebidURL));
-	log(`Prebid check: Complete`);
+	log(`[TEST 4: PUBMATIC] Step complete`);
+	// --------------- PUBMATIC END ---------------------------
+
+	// --------------- PBJS START ---------------------------
+	log(`[TEST 4: PBJS] Step start`);
+	const hasPrebid = await page.evaluate(() => window.pbjs !== undefined);
+	if (!hasPrebid) {
+		logError('[TEST 4: PBJS] Prebid.js is not loaded');
+		throw new Error('Prebid.js is missing');
+	}
+	log(`[TEST 4: PBJS] Step complete`);
+	// --------------- PBJS END ---------------------------
+
+	// --------------- BID RESPONSE START ---------------------------
+	log(`[TEST 4: BID RESPONSE] Step start`);
+	const bidResponses = await page.evaluate(() => {
+		if (window.pbjs) {
+			return pbjs.getBidResponses()['dfp-ad--top-above-nav'];
+		} else {
+			return null;
+		}
+	});
+
+	if (bidResponses) {
+		log(
+			`[TEST 4: BID RESPONSE] Bid Response for top-above-nav complete: ${JSON.stringify(
+				bidResponses,
+			)}`,
+		);
+	} else {
+		logError(
+			'[TEST 4: BID RESPONSE] Bid Response for top-above-nav is null or pbjs is not defined',
+		);
+	}
+	log(`[TEST 4: BID RESPONSE] Step complete`);
+	// --------------- BID RESPONSE END ---------------------------
 };
 
 const loadPage = async (page, url) => {
@@ -161,19 +222,24 @@ const checkPage = async (pageType, url) => {
 	await clearCookies(page);
 
 	// Now we can run our tests.
-	log(`Test 1 start: Adverts load and the CMP is displayed on initial load`);
+	log(`[TEST 1] start: CMP loads and the ads are NOT displayed on initial load`);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkCMPIsOnPage(page);
-	await checkTopAdHasLoaded(page);
-	log(`Test 1 completed`);
+	await checkTopAdDidNotLoad(page);
+	log(`[TEST 1] completed`);
 
 	log(
-		`Test 2 start: Adverts load and the CMP is NOT displayed following interaction with the CMP`,
+		`[TEST 2] start: Adverts load and the CMP is NOT displayed following interaction with the CMP`,
 	);
 	await interactWithCMP(page);
 	await checkCMPIsNotVisible(page);
+	await checkTopAdHasLoaded(page);
+	log(`[TEST 2]  completed`);
 
+	log(
+		`[TEST 3] start: Adverts load and the CMP is NOT displayed when the page is reloaded`,
+	);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
@@ -181,10 +247,14 @@ const checkPage = async (pageType, url) => {
 	);
 	await checkCMPIsNotVisible(page);
 	await checkTopAdHasLoaded(page);
-	log(`Test 2 completed`);
+	log(`[TEST 3] completed`);
+
+	log(`[TEST 4] start: Prebid`);
+	await checkPrebid(page);
+	log(`[TEST 4] completed`);
 
 	log(
-		`Test 3 start: After we clear local storage and cookies, the CMP banner is displayed once again`,
+		`[TEST 5] start: After we clear local storage and cookies, the CMP banner is displayed once again`,
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
@@ -194,12 +264,8 @@ const checkPage = async (pageType, url) => {
 		'cookies and local storage cleared then page reloaded',
 	);
 	await checkCMPIsOnPage(page);
-	await checkTopAdHasLoaded(page);
-	log(`Test 3 completed`);
-
-	log(`Test 4 start: Prebid`);
-	await checkPrebid(page);
-	log(`Test 4 completed`);
+	await checkTopAdDidNotLoad(page);
+	log(`[TEST 5] completed`);
 };
 
 const pageLoadBlueprint = async function () {

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -116,16 +116,6 @@ const checkPrebid = async (page) => {
 	log(`[TEST 4: PREBID BUNDLE] Step start`);
 	// --------------- BUNDLE END ---------------------------
 
-	// --------------- CANADA START ---------------------------
-	log(`[TEST 4: CANADA] Step start`);
-	const currentLocation = await getCurrentLocation(page);
-	if (currentLocation === 'CA') {
-		log('[TEST 4: CANADA] In Canada we do not run Prebid');
-		return Promise.resolve();
-	}
-	log(`[TEST 4: CANADA] Step complete`);
-	// --------------- CANADA END ---------------------------
-
 	// --------------- PAGESKIN START ---------------------------
 	log(`[TEST 4: PAGESKIN] Step start`);
 	const hasPageskin = await page.evaluate(() =>

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -189,7 +189,7 @@ const checkPrebid = async (page) => {
 
 	if (topAboveNavBidderRequests.length === 0) {
 		log(
-			'[TEST 4: BID RESPONSE] Bid Response for top-above-nav is null or pbjs is not defined',
+			'[TEST 4: BID RESPONSE] Bid Response not found.',
 		);
 	}
 	if (topAboveNavBidderRequests.length !== expectedBidders.length) {

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -210,13 +210,11 @@ const checkPage = async (pageType, url) => {
 	await clearCookies(page);
 
 	// Now we can run our tests.
-	log(
-		`[TEST 1] start: CMP loads and the ads are NOT displayed on initial load`,
-	);
+	log(`[Test 1] start: Adverts load and the CMP is displayed on initial load`);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkCMPIsOnPage(page);
-	await checkTopAdDidNotLoad(page);
+	await checkTopAdHasLoaded(page);
 	log(`[TEST 1] completed`);
 
 	log(
@@ -224,12 +222,7 @@ const checkPage = async (pageType, url) => {
 	);
 	await interactWithCMP(page);
 	await checkCMPIsNotVisible(page);
-	await checkTopAdHasLoaded(page);
-	log(`[TEST 2]  completed`);
 
-	log(
-		`[TEST 3] start: Adverts load and the CMP is NOT displayed when the page is reloaded`,
-	);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
@@ -237,14 +230,10 @@ const checkPage = async (pageType, url) => {
 	);
 	await checkCMPIsNotVisible(page);
 	await checkTopAdHasLoaded(page);
-	log(`[TEST 3] completed`);
-
-	log(`[TEST 4] start: Prebid`);
-	await checkPrebid(page);
-	log(`[TEST 4] completed`);
+	log(`[TEST 2]  completed`);
 
 	log(
-		`[TEST 5] start: After we clear local storage and cookies, the CMP banner is displayed once again`,
+		`[TEST 3] start: After we clear local storage and cookies, the CMP banner is displayed once again`,
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
@@ -254,8 +243,13 @@ const checkPage = async (pageType, url) => {
 		'cookies and local storage cleared then page reloaded',
 	);
 	await checkCMPIsOnPage(page);
-	await checkTopAdDidNotLoad(page);
-	log(`[TEST 5] completed`);
+	await checkTopAdHasLoaded(page);
+	log(`[TEST 3] completed`);
+
+	log(`[TEST 4] start: Prebid`);
+	await checkPrebid(page);
+	log(`[TEST 4] completed`);
+
 };
 
 const pageLoadBlueprint = async function () {

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -210,7 +210,8 @@ const checkPrebid = async (page) => {
 	expectedBidders.forEach((bidder) => {
 		if (!theActualBidders.includes(bidder)) {
 			allMatched = false;
-			log(`[TEST 4: BID RESPONSE] Missing bidder: ${bidder}`);
+			logError('[TEST 4: BID RESPONSE] Missing bidder: ${bidder}');
+			throw new Error('Bidders did not match');
 		}
 	});
 	if (allMatched) {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -128,7 +128,7 @@ const checkPrebid = async (page) => {
 
 	// --------------- PBJS START ---------------------------
 	log(`[TEST 4: PBJS] Step start`);
-	const hasPrebid = await page.evaluate(() => window.pbjs !== undefined);
+	const hasPrebid = await page.waitForFunction(() => window.pbjs !== undefined);
 	if (!hasPrebid) {
 		logError('[TEST 4: PBJS] Prebid.js is not loaded');
 		throw new Error('Prebid.js is missing');
@@ -138,7 +138,7 @@ const checkPrebid = async (page) => {
 
 	// --------------- BID RESPONSE START ---------------------------
 	log(`[TEST 4: BID RESPONSE] Step start`);
-	const bidResponses = await page.evaluate(() => {
+	const bidResponses = await page.waitForFunction(() => {
 		if (window.pbjs) {
 			return pbjs.getBidResponses()['dfp-ad--top-above-nav'];
 		} else {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -104,16 +104,6 @@ const checkPrebid = async (page) => {
 	log(`[TEST 4: PREBID BUNDLE] Step start`);
 	// --------------- BUNDLE END ---------------------------
 
-	// --------------- CANADA START ---------------------------
-	log(`[TEST 4: CANADA] Step start`);
-	const currentLocation = await getCurrentLocation(page);
-	if (currentLocation === 'CA') {
-		log('[TEST 4: CANADA] In Canada we do not run Prebid');
-		return Promise.resolve();
-	}
-	log(`[TEST 4: CANADA] Step complete`);
-	// --------------- CANADA END ---------------------------
-
 	// --------------- PAGESKIN START ---------------------------
 	log(`[TEST 4: PAGESKIN] Step start`);
 	const hasPageskin = await page.evaluate(() =>

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -207,7 +207,8 @@ const checkPrebid = async (page) => {
 	expectedBidders.forEach((bidder) => {
 		if (!theActualBidders.includes(bidder)) {
 			allMatched = false;
-			log(`[TEST 4: BID RESPONSE] Missing bidder: ${bidder}`);
+			logError('[TEST 4: BID RESPONSE] Missing bidder: ${bidder}');
+			throw new Error('Bidders did not match');
 		}
 	});
 	if (allMatched) {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -147,9 +147,7 @@ const checkPrebid = async (page) => {
 	});
 
 	if (bidResponses) {
-		log(
-			`[TEST 4: BID RESPONSE] Bid Response for top-above-nav complete`,
-		);
+		log(`[TEST 4: BID RESPONSE] Bid Response for top-above-nav complete`);
 	} else {
 		logError(
 			'[TEST 4: BID RESPONSE] Bid Response for top-above-nav is null or pbjs is not defined',
@@ -215,39 +213,27 @@ const checkPage = async (pageType, url) => {
 	await clearCookies(page);
 
 	// Now we can run our tests.
-	log(`[TEST 1] start: CMP loads and the ads are NOT displayed on initial load`);
+	log(`[TEST 1] start: Adverts load and the CMP is displayed on initial load`);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkCMPIsOnPage(page);
-	await checkTopAdDidNotLoad(page);
+	await checkTopAdHasLoaded(page);
 	log(`[TEST 1] completed`);
 
 	log(
-		`[TEST 2] start: Adverts load and the CMP is NOT displayed following interaction with the CMP`,
+		`[Test 2] start: Adverts load and the CMP is NOT displayed following interaction with the CMP`,
 	);
 	await interactWithCMP(page);
 	await checkCMPIsNotVisible(page);
-	await checkTopAdHasLoaded(page);
-	log(`[TEST 2]  completed`);
-
-	log(
-		`[TEST 3] start: Adverts load and the CMP is NOT displayed when the page is reloaded`,
-	);
-	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'CMP clicked then page reloaded',
 	);
-	await checkCMPIsNotVisible(page);
 	await checkTopAdHasLoaded(page);
-	log(`[TEST 3] completed`);
-
-	log(`[TEST 4] start: Prebid`);
-	await checkPrebid(page);
-	log(`[TEST 4] completed`);
+	log(`[TEST 2]  completed`);
 
 	log(
-		`[TEST 5] start: After we clear local storage and cookies, the CMP banner is displayed once again`,
+		`[TEST 3] start: After we clear local storage and cookies, the CMP banner is displayed once again`,
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
@@ -257,8 +243,13 @@ const checkPage = async (pageType, url) => {
 		'cookies and local storage cleared then page reloaded',
 	);
 	await checkCMPIsOnPage(page);
-	await checkTopAdDidNotLoad(page);
-	log(`[TEST 5] completed`);
+	await checkTopAdHasLoaded(page);
+	log(`[TEST 3] completed`);
+
+	log(`[TEST 4] start: Prebid`);
+	await checkPrebid(page);
+	log(`[TEST 4] completed`);
+
 };
 
 const pageLoadBlueprint = async function () {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -188,7 +188,7 @@ const checkPrebid = async (page) => {
 
 	if (topAboveNavBidderRequests.length === 0) {
 		log(
-			'[TEST 4: BID RESPONSE] Bid Response for top-above-nav is null or pbjs is not defined',
+			'[TEST 4: BID RESPONSE] Bid Response not found.',
 		);
 	}
 	if (topAboveNavBidderRequests.length !== expectedBidders.length) {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -158,9 +158,7 @@ const checkPrebid = async (page) => {
 
 	if (bidResponses) {
 		log(
-			`[TEST 4: BID RESPONSE] Bid Response for top-above-nav complete: ${JSON.stringify(
-				bidResponses,
-			)}`,
+			`[TEST 4: BID RESPONSE] Bid Response for top-above-nav complete`,
 		);
 	} else {
 		logError(

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -83,31 +83,92 @@ const checkCMPIsNotVisible = async (page) => {
 };
 
 const checkPrebid = async (page) => {
-	log(`Reloading page: Start`);
+	// --------------- RELOAD PAGE START ---------------------------
+	log(`[TEST 4: RELOAD PAGE] Step start`);
 	const reloadResponse = await page.reload({
 		waitUntil: 'domcontentloaded',
 		timeout: 30000,
 	});
 	if (!reloadResponse) {
-		logError(`Reloading page : Failed`);
+		logError(`[TEST 4: RELOAD PAGE] Reloading page : Failed`);
 		throw 'Failed to refresh page!';
 	}
-	log(`Reloading page: Complete`);
+	log(`[TEST 4: RELOAD PAGE] Step complete`);
+	// --------------- RELOAD PAGE END ---------------------------
 
+	// --------------- BUNDLE START ---------------------------
+	log(`[TEST 4: PREBID BUNDLE] Checking: graun.Prebid.js.commercial.js`);
+	await page.waitForRequest((req) =>
+		req.url().includes('graun.Prebid.js.commercial.js'),
+	);
+	log(`[TEST 4: PREBID BUNDLE] Step start`);
+	// --------------- BUNDLE END ---------------------------
+
+	// --------------- CANADA START ---------------------------
+	log(`[TEST 4: CANADA] Step start`);
+	const currentLocation = await getCurrentLocation(page);
+	if (currentLocation === 'CA') {
+		log('[TEST 4: CANADA] In Canada we do not run Prebid');
+		return Promise.resolve();
+	}
+	log(`[TEST 4: CANADA] Step complete`);
+	// --------------- CANADA END ---------------------------
+
+	// --------------- PAGESKIN START ---------------------------
+	log(`[TEST 4: PAGESKIN] Step start`);
 	const hasPageskin = await page.evaluate(() =>
 		document.body.classList.contains('has-page-skin'),
 	);
 
 	if (hasPageskin) {
-		log('Pageskin detected. Prebid will not run');
+		log('[TEST 4: PAGESKIN] Pageskin detected. Prebid will not run');
 		return Promise.resolve();
 	}
+	log(`[TEST 4: PAGESKIN] Step complete`);
+	// --------------- PAGESKIN END ---------------------------
 
+	// --------------- PUBMATIC START ---------------------------
+	log(`[TEST 4: PUBMATIC] Step start`);
 	const prebidURL =
 		'https://hbopenbid.pubmatic.com/translator?source=prebid-client';
 
 	await page.waitForRequest((req) => req.url().includes(prebidURL));
-	log(`Prebid check: Complete`);
+	log(`[TEST 4: PUBMATIC] Step complete`);
+	// --------------- PUBMATIC END ---------------------------
+
+	// --------------- PBJS START ---------------------------
+	log(`[TEST 4: PBJS] Step start`);
+	const hasPrebid = await page.evaluate(() => window.pbjs !== undefined);
+	if (!hasPrebid) {
+		logError('[TEST 4: PBJS] Prebid.js is not loaded');
+		throw new Error('Prebid.js is missing');
+	}
+	log(`[TEST 4: PBJS] Step complete`);
+	// --------------- PBJS END ---------------------------
+
+	// --------------- BID RESPONSE START ---------------------------
+	log(`[TEST 4: BID RESPONSE] Step start`);
+	const bidResponses = await page.evaluate(() => {
+		if (window.pbjs) {
+			return pbjs.getBidResponses()['dfp-ad--top-above-nav'];
+		} else {
+			return null;
+		}
+	});
+
+	if (bidResponses) {
+		log(
+			`[TEST 4: BID RESPONSE] Bid Response for top-above-nav complete: ${JSON.stringify(
+				bidResponses,
+			)}`,
+		);
+	} else {
+		logError(
+			'[TEST 4: BID RESPONSE] Bid Response for top-above-nav is null or pbjs is not defined',
+		);
+	}
+	log(`[TEST 4: BID RESPONSE] Step complete`);
+	// --------------- BID RESPONSE END ---------------------------
 };
 
 const reloadPage = async (page) => {
@@ -166,27 +227,39 @@ const checkPage = async (pageType, url) => {
 	await clearCookies(page);
 
 	// Now we can run our tests.
-	log(`Test 1 start: Adverts load and the CMP is displayed on initial load`);
+	log(`[TEST 1] start: CMP loads and the ads are NOT displayed on initial load`);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkCMPIsOnPage(page);
-	await checkTopAdHasLoaded(page);
-	log(`Test 1 completed`);
+	await checkTopAdDidNotLoad(page);
+	log(`[TEST 1] completed`);
 
 	log(
-		`Test 2 start: Adverts load and the CMP is NOT displayed following interaction with the CMP`,
+		`[TEST 2] start: Adverts load and the CMP is NOT displayed following interaction with the CMP`,
 	);
 	await interactWithCMP(page);
 	await checkCMPIsNotVisible(page);
+	await checkTopAdHasLoaded(page);
+	log(`[TEST 2]  completed`);
+
+	log(
+		`[TEST 3] start: Adverts load and the CMP is NOT displayed when the page is reloaded`,
+	);
+	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,
 		'CMP clicked then page reloaded',
 	);
+	await checkCMPIsNotVisible(page);
 	await checkTopAdHasLoaded(page);
-	log(`Test 2 completed`);
+	log(`[TEST 3] completed`);
+
+	log(`[TEST 4] start: Prebid`);
+	await checkPrebid(page);
+	log(`[TEST 4] completed`);
 
 	log(
-		`Test 3 start: After we clear local storage and cookies, the CMP banner is displayed once again`,
+		`[TEST 5] start: After we clear local storage and cookies, the CMP banner is displayed once again`,
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
@@ -196,12 +269,8 @@ const checkPage = async (pageType, url) => {
 		'cookies and local storage cleared then page reloaded',
 	);
 	await checkCMPIsOnPage(page);
-	await checkTopAdHasLoaded(page);
-	log(`Test 3 completed`);
-
-	log(`Test 4 start: Prebid`);
-	await checkPrebid(page);
-	log(`Test 4 completed`);
+	await checkTopAdDidNotLoad(page);
+	log(`[TEST 5] completed`);
 };
 
 const pageLoadBlueprint = async function () {

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -256,7 +256,7 @@ const checkPrebid = async (page) => {
 
 	if (topAboveNavBidderRequests.length === 0) {
 		log(
-			'[TEST 4: BID RESPONSE] Bid Response for top-above-nav is null or pbjs is not defined',
+			'[TEST 4: BID RESPONSE] Bid Response not found.'
 		);
 	}
 	if (topAboveNavBidderRequests.length !== expectedBidders.length) {

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -148,55 +148,71 @@ const getCurrentLocation = async (page) => {
 };
 
 const checkPrebid = async (page) => {
-	log(`Reloading page: Start`);
+	// --------------- RELOAD PAGE START ---------------------------
+	log(`[TEST 4: RELOAD PAGE] Step start`);
 	const reloadResponse = await page.reload({
 		waitUntil: 'domcontentloaded',
 		timeout: 30000,
 	});
 	if (!reloadResponse) {
-		logError(`Reloading page : Failed`);
+		logError(`[TEST 4: RELOAD PAGE] Reloading page : Failed`);
 		throw 'Failed to refresh page!';
 	}
-	log(`Reloading page: Complete`);
+	log(`[TEST 4: RELOAD PAGE] Step complete`);
+	// --------------- RELOAD PAGE END ---------------------------
 
+	// --------------- BUNDLE START ---------------------------
+	log(`[TEST 4: PREBID BUNDLE] Checking: graun.Prebid.js.commercial.js`);
+	await page.waitForRequest((req) =>
+		req.url().includes('graun.Prebid.js.commercial.js'),
+	);
+	log(`[TEST 4: PREBID BUNDLE] Step start`);
+	// --------------- BUNDLE END ---------------------------
+
+	// --------------- CANADA START ---------------------------
+	log(`[TEST 4: CANADA] Step start`);
 	const currentLocation = await getCurrentLocation(page);
 	if (currentLocation === 'CA') {
-		log('In Canada we do not run Prebid');
+		log('[TEST 4: CANADA] In Canada we do not run Prebid');
 		return Promise.resolve();
 	}
+	log(`[TEST 4: CANADA] Step complete`);
+	// --------------- CANADA END ---------------------------
 
+	// --------------- PAGESKIN START ---------------------------
+	log(`[TEST 4: PAGESKIN] Step start`);
 	const hasPageskin = await page.evaluate(() =>
 		document.body.classList.contains('has-page-skin'),
 	);
 
 	if (hasPageskin) {
-		log('Pageskin detected. Prebid will not run');
+		log('[TEST 4: PAGESKIN] Pageskin detected. Prebid will not run');
 		return Promise.resolve();
 	}
+	log(`[TEST 4: PAGESKIN] Step complete`);
+	// --------------- PAGESKIN END ---------------------------
 
-	log(`Checking: graun.Prebid.js.commercial.js`);
-	await page.waitForRequest((req) =>
-		req.url().includes('graun.Prebid.js.commercial.js'),
-	);
-	log(`Module: graun.Prebid.js.commercial.js check: Complete`);
-
-	log(`Checking Pubmatic Prebid`);
+	// --------------- PUBMATIC START ---------------------------
+	log(`[TEST 4: PUBMATIC] Step start`);
 	const prebidURL =
 		'https://hbopenbid.pubmatic.com/translator?source=prebid-client';
 
 	await page.waitForRequest((req) => req.url().includes(prebidURL));
-	log(`Pubmatic Prebid check: Complete`);
+	log(`[TEST 4: PUBMATIC] Step complete`);
+	// --------------- PUBMATIC END ---------------------------
 
-	log(`Prebid.js is present on the window: ${hasPrebid}`);
+	// --------------- PBJS START ---------------------------
+	log(`[TEST 4: PBJS] Step start`);
 	const hasPrebid = await page.evaluate(() => window.pbjs !== undefined);
 	if (!hasPrebid) {
-		logError('Prebid.js is not loaded');
+		logError('[TEST 4: PBJS] Prebid.js is not loaded');
 		throw new Error('Prebid.js is missing');
 	}
-	log(`Prebid.js is present on the window: ${hasPrebid}`);
+	log(`[TEST 4: PBJS] Step complete`);
+	// --------------- PBJS END ---------------------------
 
-
-	log(`Checking Bid Response for top-above-nav`);
+	// --------------- BID RESPONSE START ---------------------------
+	log(`[TEST 4: BID RESPONSE] Step start`);
 	const bidResponses = await page.evaluate(() => {
 		if (window.pbjs) {
 			return pbjs.getBidResponses()['dfp-ad--top-above-nav'];
@@ -207,16 +223,18 @@ const checkPrebid = async (page) => {
 
 	if (bidResponses) {
 		log(
-			`Bid Response for top-above-nav complete: ${JSON.stringify(
+			`[TEST 4: BID RESPONSE] Bid Response for top-above-nav complete: ${JSON.stringify(
 				bidResponses,
 			)}`,
 		);
 	} else {
-		logError('Bid Response for top-above-nav is null or pbjs is not defined');
+		logError(
+			'[TEST 4: BID RESPONSE] Bid Response for top-above-nav is null or pbjs is not defined',
+		);
 	}
-	log(`Checking Bid Response for top-above-nav: Complete`);
+	log(`[TEST 4: BID RESPONSE] Step complete`);
+	// --------------- BID RESPONSE END ---------------------------
 };
-
 /**
  * Checks that ads load correctly for the first time a user goes to
  * the site, with respect to and interaction with the CMP.
@@ -233,23 +251,23 @@ const checkPage = async (pageType, url) => {
 	await clearCookies(page);
 
 	// Now we can run our tests.
-	log(`Test 1 start: CMP loads and the ads are NOT displayed on initial load`);
+	log(`[TEST 1] start: CMP loads and the ads are NOT displayed on initial load`);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(`${pageType}-page`, 'page loaded');
 	await checkCMPIsOnPage(page);
 	await checkTopAdDidNotLoad(page);
-	log(`Test 1 completed`);
+	log(`[TEST 1] completed`);
 
 	log(
-		`Test 2 start: Adverts load and the CMP is NOT displayed following interaction with the CMP`,
+		`[TEST 2] start: Adverts load and the CMP is NOT displayed following interaction with the CMP`,
 	);
 	await interactWithCMP(page);
 	await checkCMPIsNotVisible(page);
 	await checkTopAdHasLoaded(page);
-	log(`Test 2 completed`);
+	log(`[TEST 2]  completed`);
 
 	log(
-		`Test 3 start: Adverts load and the CMP is NOT displayed when the page is reloaded`,
+		`[TEST 3] start: Adverts load and the CMP is NOT displayed when the page is reloaded`,
 	);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
@@ -258,14 +276,14 @@ const checkPage = async (pageType, url) => {
 	);
 	await checkCMPIsNotVisible(page);
 	await checkTopAdHasLoaded(page);
-	log(`Test 3 completed`);
+	log(`[TEST 3] completed`);
 
-	log(`Test 4 start: Prebid`);
+	log(`[TEST 4] start: Prebid`);
 	await checkPrebid(page);
-	log(`Test 4 completed`);
+	log(`[TEST 4] completed`);
 
 	log(
-		`Test 5 start: After we clear local storage and cookies, the CMP banner is displayed once again`,
+		`[TEST 5] start: After we clear local storage and cookies, the CMP banner is displayed once again`,
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
@@ -276,8 +294,9 @@ const checkPage = async (pageType, url) => {
 	);
 	await checkCMPIsOnPage(page);
 	await checkTopAdDidNotLoad(page);
-	log(`Test 5 completed`);
+	log(`[TEST 5] completed`);
 };
+
 
 const pageLoadBlueprint = async function () {
 	const synConfig = synthetics.getConfiguration();

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -179,6 +179,39 @@ const checkPrebid = async (page) => {
 
 	await page.waitForRequest((req) => req.url().includes(prebidURL));
 	log(`Prebid check: Complete`);
+
+	try {
+		await page.waitForRequest((req) => req.url().includes('prebid')),
+			{ timeout: 15000 }; // Reduce timeout to 15s
+	} catch (e) {
+		logError('Prebid.js is not loaded > error:', e);
+		throw e;
+	}
+
+	try {
+		await page.waitForRequest(
+			(req) => req.url().includes('graun.Prebid.js.commercial.js'),
+			{ timeout: 15000 }, // Reduce timeout to 15s
+		);
+		log('Prebid script loaded successfully');
+	} catch (e) {
+		logError('graun.Prebid.js.commercial.js is not loaded > error:', e);
+		throw e;
+	}
+
+	log(`Module: graun.Prebid.js.commercial.js check: Complete`);
+
+	const hasPrebid = await page.evaluate(() => window.pbjs !== undefined);
+	if (!hasPrebid) {
+		logError('Prebid.js is not loaded');
+		throw new Error('Prebid.js is missing');
+	}
+	log(`Prebid.js is present: ${hasPrebid}`);
+
+	const bidResponses = await page.evaluate(
+		() => pbjs.getBidResponses()['dfp-ad--top-above-nav'],
+	);
+	console.log(`Bid Response for top-above-nav complete: ${bidResponses}`);
 };
 
 /**

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -223,9 +223,7 @@ const checkPrebid = async (page) => {
 
 	if (bidResponses) {
 		log(
-			`[TEST 4: BID RESPONSE] Bid Response for top-above-nav complete: ${JSON.stringify(
-				bidResponses,
-			)}`,
+			`[TEST 4: BID RESPONSE] Bid Response for top-above-nav complete`,
 		);
 	} else {
 		logError(

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -203,7 +203,7 @@ const checkPrebid = async (page) => {
 
 	// --------------- PBJS START ---------------------------
 	log(`[TEST 4: PBJS] Step start`);
-	const hasPrebid = await page.evaluate(() => window.pbjs !== undefined);
+	const hasPrebid = await page.waitForFunction(() => window.pbjs !== undefined);
 	if (!hasPrebid) {
 		logError('[TEST 4: PBJS] Prebid.js is not loaded');
 		throw new Error('Prebid.js is missing');
@@ -213,7 +213,7 @@ const checkPrebid = async (page) => {
 
 	// --------------- BID RESPONSE START ---------------------------
 	log(`[TEST 4: BID RESPONSE] Step start`);
-	const bidResponses = await page.evaluate(() => {
+	const bidResponses = await page.waitForFunction(() => {
 		if (window.pbjs) {
 			return pbjs.getBidResponses()['dfp-ad--top-above-nav'];
 		} else {

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -268,7 +268,7 @@ const checkPrebid = async (page) => {
 	const theActualBidders = topAboveNavBidderRequests.map(
 		(bidder) => bidder.bidderCode,
 	);
-	log(`Actual Bidders ${JSON.stringify(theActualBidders)}`);
+	log(`[TEST 4: BID RESPONSE] Actual Bidders ${JSON.stringify(theActualBidders)}`);
 
 	let allMatched = true;
 

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -275,7 +275,9 @@ const checkPrebid = async (page) => {
 	expectedBidders.forEach((bidder) => {
 		if (!theActualBidders.includes(bidder)) {
 			allMatched = false;
-			log(`[TEST 4: BID RESPONSE] Missing bidder: ${bidder}`);
+			logError('[TEST 4: BID RESPONSE] Missing bidder: ${bidder}');
+			throw new Error('Bidders did not match');
+
 		}
 	});
 	if (allMatched) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Add prebid checks from our E2E tests to our Canaries.

We have added more checks to test the needs from the E2E tests:
- check if prebid.js is loaded
- check if PBJS is loaded in the window
-  check fr bid response
- Updated for all regions UK, US, AU
  - takes into account CA and not testing prebid

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Testing can be done by deploying to CODE and checking in AWS Synthetics:
https://github.com/guardian/commercial-canaries?tab=readme-ov-file#development

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?
That all checks pass and successful logging for accurate debugging.
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

co-authored: @cemms1 