### PR TITLE
move canada location check before prebid bundle test

### DIFF
--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -161,14 +161,6 @@ const checkPrebid = async (page) => {
 	log(`[TEST 4: RELOAD PAGE] Step complete`);
 	// --------------- RELOAD PAGE END ---------------------------
 
-	// --------------- BUNDLE START ---------------------------
-	log(`[TEST 4: PREBID BUNDLE] Checking: graun.Prebid.js.commercial.js`);
-	await page.waitForRequest((req) =>
-		req.url().includes('graun.Prebid.js.commercial.js'),
-	);
-	log(`[TEST 4: PREBID BUNDLE] Step start`);
-	// --------------- BUNDLE END ---------------------------
-
 	// --------------- CANADA START ---------------------------
 	log(`[TEST 4: CANADA] Step start`);
 	const currentLocation = await getCurrentLocation(page);
@@ -178,6 +170,14 @@ const checkPrebid = async (page) => {
 	}
 	log(`[TEST 4: CANADA] Step complete`);
 	// --------------- CANADA END ---------------------------
+
+	// --------------- BUNDLE START ---------------------------
+	log(`[TEST 4: PREBID BUNDLE] Checking: graun.Prebid.js.commercial.js`);
+	await page.waitForRequest((req) =>
+		req.url().includes('graun.Prebid.js.commercial.js'),
+	);
+	log(`[TEST 4: PREBID BUNDLE] Step start`);
+	// --------------- BUNDLE END ---------------------------
 
 	// --------------- PAGESKIN START ---------------------------
 	log(`[TEST 4: PAGESKIN] Step start`);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This checks for the currentLocation, before the check for the prebid bundle. This is a slight retrospective fix to the related PR [here](https://github.com/guardian/commercial-canaries/pull/68).
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Deploy manually to AWS synthetics CODE in canada region `ca-cenral-1`.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
