### PR TITLE
Fix email alert for UK, EU, US regions 

### DIFF
--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -256,6 +256,7 @@ Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
+        "Region": "ap-southeast-2",
         "TopicArn": Object {
           "Ref": "TopicCODEA0288998",
         },
@@ -545,6 +546,7 @@ Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
+        "Region": "ap-southeast-2",
         "TopicArn": Object {
           "Ref": "TopicPROD02C7A195",
         },
@@ -834,6 +836,7 @@ Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
+        "Region": "ca-central-1",
         "TopicArn": Object {
           "Ref": "TopicCODEA0288998",
         },
@@ -1123,6 +1126,7 @@ Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
+        "Region": "ca-central-1",
         "TopicArn": Object {
           "Ref": "TopicPROD02C7A195",
         },
@@ -1412,6 +1416,7 @@ Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
+        "Region": "eu-west-1",
         "TopicArn": Object {
           "Ref": "TopicCODEA0288998",
         },
@@ -1701,6 +1706,7 @@ Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
+        "Region": "eu-west-1",
         "TopicArn": Object {
           "Ref": "TopicPROD02C7A195",
         },
@@ -1990,6 +1996,7 @@ Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
+        "Region": "us-west-1",
         "TopicArn": Object {
           "Ref": "TopicCODEA0288998",
         },
@@ -2279,6 +2286,7 @@ Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
+        "Region": "us-west-1",
         "TopicArn": Object {
           "Ref": "TopicPROD02C7A195",
         },

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -13,16 +13,16 @@ Object {
     },
   },
   "Resources": Object {
-    "AlarmCODE09E73206": Object {
+    "Alarm7103F465": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicCODEapsoutheast2E8902FA1",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "AlarmDescription": "Either a Front or an Article CMP has failed in ap-southeast-2",
-        "AlarmName": "commercial-canary-CODE-ap-southeast-2",
+        "AlarmName": "commercial-canary-CODE",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -36,7 +36,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicCODEapsoutheast2E8902FA1",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "Period": 60,
@@ -252,18 +252,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionCODEapsoutheast21E1B4D9D": Object {
+    "Subscription391C9821": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries+CODE-ap-southeast-2@guardian.co.uk",
         "Protocol": "email",
         "Region": "ap-southeast-2",
         "TopicArn": Object {
-          "Ref": "TopicCODEapsoutheast2E8902FA1",
+          "Ref": "TopicBFC7AF6E",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicCODEapsoutheast2E8902FA1": Object {
+    "TopicBFC7AF6E": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -303,16 +303,16 @@ Object {
     },
   },
   "Resources": Object {
-    "AlarmPROD8A842476": Object {
+    "Alarm7103F465": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicPRODapsoutheast2108028D5",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "AlarmDescription": "Either a Front or an Article CMP has failed in ap-southeast-2",
-        "AlarmName": "commercial-canary-PROD-ap-southeast-2",
+        "AlarmName": "commercial-canary-PROD",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -326,7 +326,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicPRODapsoutheast2108028D5",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "Period": 60,
@@ -542,18 +542,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionPRODapsoutheast241550A69": Object {
+    "Subscription391C9821": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries+PROD-ap-southeast-2@guardian.co.uk",
         "Protocol": "email",
         "Region": "ap-southeast-2",
         "TopicArn": Object {
-          "Ref": "TopicPRODapsoutheast2108028D5",
+          "Ref": "TopicBFC7AF6E",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicPRODapsoutheast2108028D5": Object {
+    "TopicBFC7AF6E": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -593,16 +593,16 @@ Object {
     },
   },
   "Resources": Object {
-    "AlarmCODE09E73206": Object {
+    "Alarm7103F465": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicCODEcacentral1CD569A70",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "AlarmDescription": "Either a Front or an Article CMP has failed in ca-central-1",
-        "AlarmName": "commercial-canary-CODE-ca-central-1",
+        "AlarmName": "commercial-canary-CODE",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -616,7 +616,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicCODEcacentral1CD569A70",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "Period": 60,
@@ -832,18 +832,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionCODEcacentral1443D4638": Object {
+    "Subscription391C9821": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries+CODE-ca-central-1@guardian.co.uk",
         "Protocol": "email",
         "Region": "ca-central-1",
         "TopicArn": Object {
-          "Ref": "TopicCODEcacentral1CD569A70",
+          "Ref": "TopicBFC7AF6E",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicCODEcacentral1CD569A70": Object {
+    "TopicBFC7AF6E": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -883,16 +883,16 @@ Object {
     },
   },
   "Resources": Object {
-    "AlarmPROD8A842476": Object {
+    "Alarm7103F465": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicPRODcacentral14C91E7FF",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "AlarmDescription": "Either a Front or an Article CMP has failed in ca-central-1",
-        "AlarmName": "commercial-canary-PROD-ca-central-1",
+        "AlarmName": "commercial-canary-PROD",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -906,7 +906,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicPRODcacentral14C91E7FF",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "Period": 60,
@@ -1122,18 +1122,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionPRODcacentral1485BD312": Object {
+    "Subscription391C9821": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries+PROD-ca-central-1@guardian.co.uk",
         "Protocol": "email",
         "Region": "ca-central-1",
         "TopicArn": Object {
-          "Ref": "TopicPRODcacentral14C91E7FF",
+          "Ref": "TopicBFC7AF6E",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicPRODcacentral14C91E7FF": Object {
+    "TopicBFC7AF6E": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -1173,16 +1173,16 @@ Object {
     },
   },
   "Resources": Object {
-    "AlarmCODE09E73206": Object {
+    "Alarm7103F465": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicCODEeuwest18E4F95DD",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "AlarmDescription": "Either a Front or an Article CMP has failed in eu-west-1",
-        "AlarmName": "commercial-canary-CODE-eu-west-1",
+        "AlarmName": "commercial-canary-CODE",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -1196,7 +1196,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicCODEeuwest18E4F95DD",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "Period": 60,
@@ -1412,18 +1412,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionCODEeuwest1D9A99453": Object {
+    "Subscription391C9821": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries+CODE-eu-west-1@guardian.co.uk",
         "Protocol": "email",
         "Region": "eu-west-1",
         "TopicArn": Object {
-          "Ref": "TopicCODEeuwest18E4F95DD",
+          "Ref": "TopicBFC7AF6E",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicCODEeuwest18E4F95DD": Object {
+    "TopicBFC7AF6E": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -1463,16 +1463,16 @@ Object {
     },
   },
   "Resources": Object {
-    "AlarmPROD8A842476": Object {
+    "Alarm7103F465": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicPRODeuwest132F1B0C5",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "AlarmDescription": "Either a Front or an Article CMP has failed in eu-west-1",
-        "AlarmName": "commercial-canary-PROD-eu-west-1",
+        "AlarmName": "commercial-canary-PROD",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -1486,7 +1486,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicPRODeuwest132F1B0C5",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "Period": 60,
@@ -1702,18 +1702,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionPRODeuwest18472BFD2": Object {
+    "Subscription391C9821": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries+PROD-eu-west-1@guardian.co.uk",
         "Protocol": "email",
         "Region": "eu-west-1",
         "TopicArn": Object {
-          "Ref": "TopicPRODeuwest132F1B0C5",
+          "Ref": "TopicBFC7AF6E",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicPRODeuwest132F1B0C5": Object {
+    "TopicBFC7AF6E": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -1753,16 +1753,16 @@ Object {
     },
   },
   "Resources": Object {
-    "AlarmCODE09E73206": Object {
+    "Alarm7103F465": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicCODEuswest1BCC7F1D9",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "AlarmDescription": "Either a Front or an Article CMP has failed in us-west-1",
-        "AlarmName": "commercial-canary-CODE-us-west-1",
+        "AlarmName": "commercial-canary-CODE",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -1776,7 +1776,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicCODEuswest1BCC7F1D9",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "Period": 60,
@@ -1992,18 +1992,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionCODEuswest176FCF696": Object {
+    "Subscription391C9821": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries+CODE-us-west-1@guardian.co.uk",
         "Protocol": "email",
         "Region": "us-west-1",
         "TopicArn": Object {
-          "Ref": "TopicCODEuswest1BCC7F1D9",
+          "Ref": "TopicBFC7AF6E",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicCODEuswest1BCC7F1D9": Object {
+    "TopicBFC7AF6E": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -2043,16 +2043,16 @@ Object {
     },
   },
   "Resources": Object {
-    "AlarmPROD8A842476": Object {
+    "Alarm7103F465": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicPRODuswest13F6F85C0",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "AlarmDescription": "Either a Front or an Article CMP has failed in us-west-1",
-        "AlarmName": "commercial-canary-PROD-us-west-1",
+        "AlarmName": "commercial-canary-PROD",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -2066,7 +2066,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicPRODuswest13F6F85C0",
+            "Ref": "TopicBFC7AF6E",
           },
         ],
         "Period": 60,
@@ -2282,18 +2282,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionPRODuswest1F1008298": Object {
+    "Subscription391C9821": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries+PROD-us-west-1@guardian.co.uk",
         "Protocol": "email",
         "Region": "us-west-1",
         "TopicArn": Object {
-          "Ref": "TopicPRODuswest13F6F85C0",
+          "Ref": "TopicBFC7AF6E",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicPRODuswest13F6F85C0": Object {
+    "TopicBFC7AF6E": Object {
       "Properties": Object {
         "Tags": Array [
           Object {

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -13,39 +13,6 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed in ap-southeast-2",
-        "AlarmName": "commercial-canary-CODE",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "DatapointsToAlarm": 5,
-        "Dimensions": Array [
-          Object {
-            "Name": "CanaryName",
-            "Value": "comm_cmp_canary_code",
-          },
-        ],
-        "EvaluationPeriods": 5,
-        "MetricName": "SuccessPercent",
-        "Namespace": "CloudWatchSynthetics",
-        "OKActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "Period": 60,
-        "Statistic": "Average",
-        "Threshold": 80,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -593,39 +560,6 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed in ca-central-1",
-        "AlarmName": "commercial-canary-CODE",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "DatapointsToAlarm": 5,
-        "Dimensions": Array [
-          Object {
-            "Name": "CanaryName",
-            "Value": "comm_cmp_canary_code",
-          },
-        ],
-        "EvaluationPeriods": 5,
-        "MetricName": "SuccessPercent",
-        "Namespace": "CloudWatchSynthetics",
-        "OKActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "Period": 60,
-        "Statistic": "Average",
-        "Threshold": 80,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -1173,39 +1107,6 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed in eu-west-1",
-        "AlarmName": "commercial-canary-CODE",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "DatapointsToAlarm": 5,
-        "Dimensions": Array [
-          Object {
-            "Name": "CanaryName",
-            "Value": "comm_cmp_canary_code",
-          },
-        ],
-        "EvaluationPeriods": 5,
-        "MetricName": "SuccessPercent",
-        "Namespace": "CloudWatchSynthetics",
-        "OKActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "Period": 60,
-        "Statistic": "Average",
-        "Threshold": 80,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -1753,39 +1654,6 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed in us-west-1",
-        "AlarmName": "commercial-canary-CODE",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "DatapointsToAlarm": 5,
-        "Dimensions": Array [
-          Object {
-            "Name": "CanaryName",
-            "Value": "comm_cmp_canary_code",
-          },
-        ],
-        "EvaluationPeriods": 5,
-        "MetricName": "SuccessPercent",
-        "Namespace": "CloudWatchSynthetics",
-        "OKActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "Period": 60,
-        "Statistic": "Average",
-        "Threshold": 80,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -13,6 +13,34 @@ Object {
     },
   },
   "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "Either a Front or an Article CMP has failed",
+        "AlarmName": "Commercial canary",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "CanaryName",
+            "Value": "comm_cmp_canary_code",
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "SuccessPercent",
+        "Namespace": "CloudWatchSynthetics",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 80,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -219,6 +247,39 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
+    "Subscription391C9821": Object {
+      "Properties": Object {
+        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": Object {
+          "Ref": "TopicBFC7AF6E",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "TopicBFC7AF6E": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/commercial-canaries",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "frontend",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
   },
 }
 `;
@@ -257,11 +318,6 @@ Object {
         "EvaluationPeriods": 5,
         "MetricName": "SuccessPercent",
         "Namespace": "CloudWatchSynthetics",
-        "OKActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
         "Period": 60,
         "Statistic": "Average",
         "Threshold": 80,
@@ -475,6 +531,16 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
+    "Subscription391C9821": Object {
+      "Properties": Object {
+        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": Object {
+          "Ref": "TopicBFC7AF6E",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
     "TopicBFC7AF6E": Object {
       "Properties": Object {
         "Tags": Array [
@@ -498,16 +564,6 @@ Object {
       },
       "Type": "AWS::SNS::Topic",
     },
-    "TopiccommercialcanariesguardiancoukA88DBBEE": Object {
-      "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": Object {
-          "Ref": "TopicBFC7AF6E",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
   },
 }
 `;
@@ -525,6 +581,34 @@ Object {
     },
   },
   "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "Either a Front or an Article CMP has failed",
+        "AlarmName": "Commercial canary",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "CanaryName",
+            "Value": "comm_cmp_canary_code",
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "SuccessPercent",
+        "Namespace": "CloudWatchSynthetics",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 80,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -731,6 +815,39 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
+    "Subscription391C9821": Object {
+      "Properties": Object {
+        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": Object {
+          "Ref": "TopicBFC7AF6E",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "TopicBFC7AF6E": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/commercial-canaries",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "frontend",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
   },
 }
 `;
@@ -769,11 +886,6 @@ Object {
         "EvaluationPeriods": 5,
         "MetricName": "SuccessPercent",
         "Namespace": "CloudWatchSynthetics",
-        "OKActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
         "Period": 60,
         "Statistic": "Average",
         "Threshold": 80,
@@ -987,6 +1099,16 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
+    "Subscription391C9821": Object {
+      "Properties": Object {
+        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": Object {
+          "Ref": "TopicBFC7AF6E",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
     "TopicBFC7AF6E": Object {
       "Properties": Object {
         "Tags": Array [
@@ -1010,16 +1132,6 @@ Object {
       },
       "Type": "AWS::SNS::Topic",
     },
-    "TopiccommercialcanariesguardiancoukA88DBBEE": Object {
-      "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": Object {
-          "Ref": "TopicBFC7AF6E",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
   },
 }
 `;
@@ -1037,6 +1149,34 @@ Object {
     },
   },
   "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "Either a Front or an Article CMP has failed",
+        "AlarmName": "Commercial canary",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "CanaryName",
+            "Value": "comm_cmp_canary_code",
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "SuccessPercent",
+        "Namespace": "CloudWatchSynthetics",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 80,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -1243,6 +1383,39 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
+    "Subscription391C9821": Object {
+      "Properties": Object {
+        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": Object {
+          "Ref": "TopicBFC7AF6E",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "TopicBFC7AF6E": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/commercial-canaries",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "frontend",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
   },
 }
 `;
@@ -1281,11 +1454,6 @@ Object {
         "EvaluationPeriods": 5,
         "MetricName": "SuccessPercent",
         "Namespace": "CloudWatchSynthetics",
-        "OKActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
         "Period": 60,
         "Statistic": "Average",
         "Threshold": 80,
@@ -1499,6 +1667,16 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
+    "Subscription391C9821": Object {
+      "Properties": Object {
+        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": Object {
+          "Ref": "TopicBFC7AF6E",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
     "TopicBFC7AF6E": Object {
       "Properties": Object {
         "Tags": Array [
@@ -1522,16 +1700,6 @@ Object {
       },
       "Type": "AWS::SNS::Topic",
     },
-    "TopiccommercialcanariesguardiancoukA88DBBEE": Object {
-      "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": Object {
-          "Ref": "TopicBFC7AF6E",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
   },
 }
 `;
@@ -1549,6 +1717,34 @@ Object {
     },
   },
   "Resources": Object {
+    "Alarm7103F465": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicBFC7AF6E",
+          },
+        ],
+        "AlarmDescription": "Either a Front or an Article CMP has failed",
+        "AlarmName": "Commercial canary",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "CanaryName",
+            "Value": "comm_cmp_canary_code",
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "SuccessPercent",
+        "Namespace": "CloudWatchSynthetics",
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 80,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -1755,6 +1951,39 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
+    "Subscription391C9821": Object {
+      "Properties": Object {
+        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": Object {
+          "Ref": "TopicBFC7AF6E",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "TopicBFC7AF6E": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/commercial-canaries",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "frontend",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
+    },
   },
 }
 `;
@@ -1793,11 +2022,6 @@ Object {
         "EvaluationPeriods": 5,
         "MetricName": "SuccessPercent",
         "Namespace": "CloudWatchSynthetics",
-        "OKActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
         "Period": 60,
         "Statistic": "Average",
         "Threshold": 80,
@@ -2011,6 +2235,16 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
+    "Subscription391C9821": Object {
+      "Properties": Object {
+        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": Object {
+          "Ref": "TopicBFC7AF6E",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
     "TopicBFC7AF6E": Object {
       "Properties": Object {
         "Tags": Array [
@@ -2033,16 +2267,6 @@ Object {
         ],
       },
       "Type": "AWS::SNS::Topic",
-    },
-    "TopiccommercialcanariesguardiancoukA88DBBEE": Object {
-      "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": Object {
-          "Ref": "TopicBFC7AF6E",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
     },
   },
 }

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -254,7 +254,7 @@ Object {
     },
     "SubscriptionCODEapsoutheast21E1B4D9D": Object {
       "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Endpoint": "commercial.canaries+CODE-ap-southeast-2@guardian.co.uk",
         "Protocol": "email",
         "Region": "ap-southeast-2",
         "TopicArn": Object {
@@ -544,7 +544,7 @@ Object {
     },
     "SubscriptionPRODapsoutheast241550A69": Object {
       "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Endpoint": "commercial.canaries+PROD-ap-southeast-2@guardian.co.uk",
         "Protocol": "email",
         "Region": "ap-southeast-2",
         "TopicArn": Object {
@@ -834,7 +834,7 @@ Object {
     },
     "SubscriptionCODEcacentral1443D4638": Object {
       "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Endpoint": "commercial.canaries+CODE-ca-central-1@guardian.co.uk",
         "Protocol": "email",
         "Region": "ca-central-1",
         "TopicArn": Object {
@@ -1124,7 +1124,7 @@ Object {
     },
     "SubscriptionPRODcacentral1485BD312": Object {
       "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Endpoint": "commercial.canaries+PROD-ca-central-1@guardian.co.uk",
         "Protocol": "email",
         "Region": "ca-central-1",
         "TopicArn": Object {
@@ -1414,7 +1414,7 @@ Object {
     },
     "SubscriptionCODEeuwest1D9A99453": Object {
       "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Endpoint": "commercial.canaries+CODE-eu-west-1@guardian.co.uk",
         "Protocol": "email",
         "Region": "eu-west-1",
         "TopicArn": Object {
@@ -1704,7 +1704,7 @@ Object {
     },
     "SubscriptionPRODeuwest18472BFD2": Object {
       "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Endpoint": "commercial.canaries+PROD-eu-west-1@guardian.co.uk",
         "Protocol": "email",
         "Region": "eu-west-1",
         "TopicArn": Object {
@@ -1994,7 +1994,7 @@ Object {
     },
     "SubscriptionCODEuswest176FCF696": Object {
       "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Endpoint": "commercial.canaries+CODE-us-west-1@guardian.co.uk",
         "Protocol": "email",
         "Region": "us-west-1",
         "TopicArn": Object {
@@ -2284,7 +2284,7 @@ Object {
     },
     "SubscriptionPRODuswest1F1008298": Object {
       "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Endpoint": "commercial.canaries+PROD-us-west-1@guardian.co.uk",
         "Protocol": "email",
         "Region": "us-west-1",
         "TopicArn": Object {

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -13,34 +13,6 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "Commercial canary",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "DatapointsToAlarm": 5,
-        "Dimensions": Array [
-          Object {
-            "Name": "CanaryName",
-            "Value": "comm_cmp_canary_code",
-          },
-        ],
-        "EvaluationPeriods": 5,
-        "MetricName": "SuccessPercent",
-        "Namespace": "CloudWatchSynthetics",
-        "Period": 60,
-        "Statistic": "Average",
-        "Threshold": 80,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -247,39 +219,6 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "Subscription391C9821": Object {
-      "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": Object {
-          "Ref": "TopicBFC7AF6E",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
-    "TopicBFC7AF6E": Object {
-      "Properties": Object {
-        "Tags": Array [
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/commercial-canaries",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "frontend",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::SNS::Topic",
-    },
   },
 }
 `;
@@ -297,16 +236,16 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
+    "AlarmPROD8A842476": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicBFC7AF6E",
+            "Ref": "TopicPROD02C7A195",
           },
         ],
         "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "Commercial canary",
+        "AlarmName": "commercial-canary-PROD",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -318,6 +257,11 @@ Object {
         "EvaluationPeriods": 5,
         "MetricName": "SuccessPercent",
         "Namespace": "CloudWatchSynthetics",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicPROD02C7A195",
+          },
+        ],
         "Period": 60,
         "Statistic": "Average",
         "Threshold": 80,
@@ -531,17 +475,17 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "Subscription391C9821": Object {
+    "SubscriptionPROD6213BADC": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
         "TopicArn": Object {
-          "Ref": "TopicBFC7AF6E",
+          "Ref": "TopicPROD02C7A195",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicBFC7AF6E": Object {
+    "TopicPROD02C7A195": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -581,34 +525,6 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "Commercial canary",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "DatapointsToAlarm": 5,
-        "Dimensions": Array [
-          Object {
-            "Name": "CanaryName",
-            "Value": "comm_cmp_canary_code",
-          },
-        ],
-        "EvaluationPeriods": 5,
-        "MetricName": "SuccessPercent",
-        "Namespace": "CloudWatchSynthetics",
-        "Period": 60,
-        "Statistic": "Average",
-        "Threshold": 80,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -815,39 +731,6 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "Subscription391C9821": Object {
-      "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": Object {
-          "Ref": "TopicBFC7AF6E",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
-    "TopicBFC7AF6E": Object {
-      "Properties": Object {
-        "Tags": Array [
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/commercial-canaries",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "frontend",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::SNS::Topic",
-    },
   },
 }
 `;
@@ -865,16 +748,16 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
+    "AlarmPROD8A842476": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicBFC7AF6E",
+            "Ref": "TopicPROD02C7A195",
           },
         ],
         "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "Commercial canary",
+        "AlarmName": "commercial-canary-PROD",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -886,6 +769,11 @@ Object {
         "EvaluationPeriods": 5,
         "MetricName": "SuccessPercent",
         "Namespace": "CloudWatchSynthetics",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicPROD02C7A195",
+          },
+        ],
         "Period": 60,
         "Statistic": "Average",
         "Threshold": 80,
@@ -1099,17 +987,17 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "Subscription391C9821": Object {
+    "SubscriptionPROD6213BADC": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
         "TopicArn": Object {
-          "Ref": "TopicBFC7AF6E",
+          "Ref": "TopicPROD02C7A195",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicBFC7AF6E": Object {
+    "TopicPROD02C7A195": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -1149,34 +1037,6 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "Commercial canary",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "DatapointsToAlarm": 5,
-        "Dimensions": Array [
-          Object {
-            "Name": "CanaryName",
-            "Value": "comm_cmp_canary_code",
-          },
-        ],
-        "EvaluationPeriods": 5,
-        "MetricName": "SuccessPercent",
-        "Namespace": "CloudWatchSynthetics",
-        "Period": 60,
-        "Statistic": "Average",
-        "Threshold": 80,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -1383,39 +1243,6 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "Subscription391C9821": Object {
-      "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": Object {
-          "Ref": "TopicBFC7AF6E",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
-    "TopicBFC7AF6E": Object {
-      "Properties": Object {
-        "Tags": Array [
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/commercial-canaries",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "frontend",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::SNS::Topic",
-    },
   },
 }
 `;
@@ -1433,16 +1260,16 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
+    "AlarmPROD8A842476": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicBFC7AF6E",
+            "Ref": "TopicPROD02C7A195",
           },
         ],
         "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "Commercial canary",
+        "AlarmName": "commercial-canary-PROD",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -1454,6 +1281,11 @@ Object {
         "EvaluationPeriods": 5,
         "MetricName": "SuccessPercent",
         "Namespace": "CloudWatchSynthetics",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicPROD02C7A195",
+          },
+        ],
         "Period": 60,
         "Statistic": "Average",
         "Threshold": 80,
@@ -1667,17 +1499,17 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "Subscription391C9821": Object {
+    "SubscriptionPROD6213BADC": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
         "TopicArn": Object {
-          "Ref": "TopicBFC7AF6E",
+          "Ref": "TopicPROD02C7A195",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicBFC7AF6E": Object {
+    "TopicPROD02C7A195": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -1717,34 +1549,6 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
-      "Properties": Object {
-        "ActionsEnabled": true,
-        "AlarmActions": Array [
-          Object {
-            "Ref": "TopicBFC7AF6E",
-          },
-        ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "Commercial canary",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
-        "DatapointsToAlarm": 5,
-        "Dimensions": Array [
-          Object {
-            "Name": "CanaryName",
-            "Value": "comm_cmp_canary_code",
-          },
-        ],
-        "EvaluationPeriods": 5,
-        "MetricName": "SuccessPercent",
-        "Namespace": "CloudWatchSynthetics",
-        "Period": 60,
-        "Statistic": "Average",
-        "Threshold": 80,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -1951,39 +1755,6 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "Subscription391C9821": Object {
-      "Properties": Object {
-        "Endpoint": "commercial.canaries@guardian.co.uk",
-        "Protocol": "email",
-        "TopicArn": Object {
-          "Ref": "TopicBFC7AF6E",
-        },
-      },
-      "Type": "AWS::SNS::Subscription",
-    },
-    "TopicBFC7AF6E": Object {
-      "Properties": Object {
-        "Tags": Array [
-          Object {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          Object {
-            "Key": "gu:repo",
-            "Value": "guardian/commercial-canaries",
-          },
-          Object {
-            "Key": "Stack",
-            "Value": "frontend",
-          },
-          Object {
-            "Key": "Stage",
-            "Value": "CODE",
-          },
-        ],
-      },
-      "Type": "AWS::SNS::Topic",
-    },
   },
 }
 `;
@@ -2001,16 +1772,16 @@ Object {
     },
   },
   "Resources": Object {
-    "Alarm7103F465": Object {
+    "AlarmPROD8A842476": Object {
       "Properties": Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicBFC7AF6E",
+            "Ref": "TopicPROD02C7A195",
           },
         ],
         "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "Commercial canary",
+        "AlarmName": "commercial-canary-PROD",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -2022,6 +1793,11 @@ Object {
         "EvaluationPeriods": 5,
         "MetricName": "SuccessPercent",
         "Namespace": "CloudWatchSynthetics",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicPROD02C7A195",
+          },
+        ],
         "Period": 60,
         "Statistic": "Average",
         "Threshold": 80,
@@ -2235,17 +2011,17 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "Subscription391C9821": Object {
+    "SubscriptionPROD6213BADC": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
         "TopicArn": Object {
-          "Ref": "TopicBFC7AF6E",
+          "Ref": "TopicPROD02C7A195",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicBFC7AF6E": Object {
+    "TopicPROD02C7A195": Object {
       "Properties": Object {
         "Tags": Array [
           Object {

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -13,6 +13,39 @@ Object {
     },
   },
   "Resources": Object {
+    "AlarmCODE09E73206": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicCODEA0288998",
+          },
+        ],
+        "AlarmDescription": "Either a Front or an Article CMP has failed",
+        "AlarmName": "commercial-canary-CODE",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "CanaryName",
+            "Value": "comm_cmp_canary_code",
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "SuccessPercent",
+        "Namespace": "CloudWatchSynthetics",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicCODEA0288998",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 80,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -218,6 +251,39 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "SubscriptionCODE8883E38D": Object {
+      "Properties": Object {
+        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": Object {
+          "Ref": "TopicCODEA0288998",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "TopicCODEA0288998": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/commercial-canaries",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "frontend",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
     },
   },
 }
@@ -525,6 +591,39 @@ Object {
     },
   },
   "Resources": Object {
+    "AlarmCODE09E73206": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicCODEA0288998",
+          },
+        ],
+        "AlarmDescription": "Either a Front or an Article CMP has failed",
+        "AlarmName": "commercial-canary-CODE",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "CanaryName",
+            "Value": "comm_cmp_canary_code",
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "SuccessPercent",
+        "Namespace": "CloudWatchSynthetics",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicCODEA0288998",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 80,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -730,6 +829,39 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "SubscriptionCODE8883E38D": Object {
+      "Properties": Object {
+        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": Object {
+          "Ref": "TopicCODEA0288998",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "TopicCODEA0288998": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/commercial-canaries",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "frontend",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
     },
   },
 }
@@ -1037,6 +1169,39 @@ Object {
     },
   },
   "Resources": Object {
+    "AlarmCODE09E73206": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicCODEA0288998",
+          },
+        ],
+        "AlarmDescription": "Either a Front or an Article CMP has failed",
+        "AlarmName": "commercial-canary-CODE",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "CanaryName",
+            "Value": "comm_cmp_canary_code",
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "SuccessPercent",
+        "Namespace": "CloudWatchSynthetics",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicCODEA0288998",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 80,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -1242,6 +1407,39 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "SubscriptionCODE8883E38D": Object {
+      "Properties": Object {
+        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": Object {
+          "Ref": "TopicCODEA0288998",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "TopicCODEA0288998": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/commercial-canaries",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "frontend",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
     },
   },
 }
@@ -1549,6 +1747,39 @@ Object {
     },
   },
   "Resources": Object {
+    "AlarmCODE09E73206": Object {
+      "Properties": Object {
+        "ActionsEnabled": true,
+        "AlarmActions": Array [
+          Object {
+            "Ref": "TopicCODEA0288998",
+          },
+        ],
+        "AlarmDescription": "Either a Front or an Article CMP has failed",
+        "AlarmName": "commercial-canary-CODE",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "DatapointsToAlarm": 5,
+        "Dimensions": Array [
+          Object {
+            "Name": "CanaryName",
+            "Value": "comm_cmp_canary_code",
+          },
+        ],
+        "EvaluationPeriods": 5,
+        "MetricName": "SuccessPercent",
+        "Namespace": "CloudWatchSynthetics",
+        "OKActions": Array [
+          Object {
+            "Ref": "TopicCODEA0288998",
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Average",
+        "Threshold": 80,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "Canary": Object {
       "Properties": Object {
         "ArtifactS3Location": Object {
@@ -1754,6 +1985,39 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "SubscriptionCODE8883E38D": Object {
+      "Properties": Object {
+        "Endpoint": "commercial.canaries@guardian.co.uk",
+        "Protocol": "email",
+        "TopicArn": Object {
+          "Ref": "TopicCODEA0288998",
+        },
+      },
+      "Type": "AWS::SNS::Subscription",
+    },
+    "TopicCODEA0288998": Object {
+      "Properties": Object {
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/commercial-canaries",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "frontend",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::SNS::Topic",
     },
   },
 }

--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -18,11 +18,11 @@ Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicCODEA0288998",
+            "Ref": "TopicCODEapsoutheast2E8902FA1",
           },
         ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "commercial-canary-CODE",
+        "AlarmDescription": "Either a Front or an Article CMP has failed in ap-southeast-2",
+        "AlarmName": "commercial-canary-CODE-ap-southeast-2",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -36,7 +36,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicCODEA0288998",
+            "Ref": "TopicCODEapsoutheast2E8902FA1",
           },
         ],
         "Period": 60,
@@ -252,18 +252,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionCODE8883E38D": Object {
+    "SubscriptionCODEapsoutheast21E1B4D9D": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
         "Region": "ap-southeast-2",
         "TopicArn": Object {
-          "Ref": "TopicCODEA0288998",
+          "Ref": "TopicCODEapsoutheast2E8902FA1",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicCODEA0288998": Object {
+    "TopicCODEapsoutheast2E8902FA1": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -308,11 +308,11 @@ Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicPROD02C7A195",
+            "Ref": "TopicPRODapsoutheast2108028D5",
           },
         ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "commercial-canary-PROD",
+        "AlarmDescription": "Either a Front or an Article CMP has failed in ap-southeast-2",
+        "AlarmName": "commercial-canary-PROD-ap-southeast-2",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -326,7 +326,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicPROD02C7A195",
+            "Ref": "TopicPRODapsoutheast2108028D5",
           },
         ],
         "Period": 60,
@@ -542,18 +542,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionPROD6213BADC": Object {
+    "SubscriptionPRODapsoutheast241550A69": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
         "Region": "ap-southeast-2",
         "TopicArn": Object {
-          "Ref": "TopicPROD02C7A195",
+          "Ref": "TopicPRODapsoutheast2108028D5",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicPROD02C7A195": Object {
+    "TopicPRODapsoutheast2108028D5": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -598,11 +598,11 @@ Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicCODEA0288998",
+            "Ref": "TopicCODEcacentral1CD569A70",
           },
         ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "commercial-canary-CODE",
+        "AlarmDescription": "Either a Front or an Article CMP has failed in ca-central-1",
+        "AlarmName": "commercial-canary-CODE-ca-central-1",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -616,7 +616,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicCODEA0288998",
+            "Ref": "TopicCODEcacentral1CD569A70",
           },
         ],
         "Period": 60,
@@ -832,18 +832,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionCODE8883E38D": Object {
+    "SubscriptionCODEcacentral1443D4638": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
         "Region": "ca-central-1",
         "TopicArn": Object {
-          "Ref": "TopicCODEA0288998",
+          "Ref": "TopicCODEcacentral1CD569A70",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicCODEA0288998": Object {
+    "TopicCODEcacentral1CD569A70": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -888,11 +888,11 @@ Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicPROD02C7A195",
+            "Ref": "TopicPRODcacentral14C91E7FF",
           },
         ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "commercial-canary-PROD",
+        "AlarmDescription": "Either a Front or an Article CMP has failed in ca-central-1",
+        "AlarmName": "commercial-canary-PROD-ca-central-1",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -906,7 +906,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicPROD02C7A195",
+            "Ref": "TopicPRODcacentral14C91E7FF",
           },
         ],
         "Period": 60,
@@ -1122,18 +1122,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionPROD6213BADC": Object {
+    "SubscriptionPRODcacentral1485BD312": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
         "Region": "ca-central-1",
         "TopicArn": Object {
-          "Ref": "TopicPROD02C7A195",
+          "Ref": "TopicPRODcacentral14C91E7FF",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicPROD02C7A195": Object {
+    "TopicPRODcacentral14C91E7FF": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -1178,11 +1178,11 @@ Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicCODEA0288998",
+            "Ref": "TopicCODEeuwest18E4F95DD",
           },
         ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "commercial-canary-CODE",
+        "AlarmDescription": "Either a Front or an Article CMP has failed in eu-west-1",
+        "AlarmName": "commercial-canary-CODE-eu-west-1",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -1196,7 +1196,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicCODEA0288998",
+            "Ref": "TopicCODEeuwest18E4F95DD",
           },
         ],
         "Period": 60,
@@ -1412,18 +1412,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionCODE8883E38D": Object {
+    "SubscriptionCODEeuwest1D9A99453": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
         "Region": "eu-west-1",
         "TopicArn": Object {
-          "Ref": "TopicCODEA0288998",
+          "Ref": "TopicCODEeuwest18E4F95DD",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicCODEA0288998": Object {
+    "TopicCODEeuwest18E4F95DD": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -1468,11 +1468,11 @@ Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicPROD02C7A195",
+            "Ref": "TopicPRODeuwest132F1B0C5",
           },
         ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "commercial-canary-PROD",
+        "AlarmDescription": "Either a Front or an Article CMP has failed in eu-west-1",
+        "AlarmName": "commercial-canary-PROD-eu-west-1",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -1486,7 +1486,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicPROD02C7A195",
+            "Ref": "TopicPRODeuwest132F1B0C5",
           },
         ],
         "Period": 60,
@@ -1702,18 +1702,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionPROD6213BADC": Object {
+    "SubscriptionPRODeuwest18472BFD2": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
         "Region": "eu-west-1",
         "TopicArn": Object {
-          "Ref": "TopicPROD02C7A195",
+          "Ref": "TopicPRODeuwest132F1B0C5",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicPROD02C7A195": Object {
+    "TopicPRODeuwest132F1B0C5": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -1758,11 +1758,11 @@ Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicCODEA0288998",
+            "Ref": "TopicCODEuswest1BCC7F1D9",
           },
         ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "commercial-canary-CODE",
+        "AlarmDescription": "Either a Front or an Article CMP has failed in us-west-1",
+        "AlarmName": "commercial-canary-CODE-us-west-1",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -1776,7 +1776,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicCODEA0288998",
+            "Ref": "TopicCODEuswest1BCC7F1D9",
           },
         ],
         "Period": 60,
@@ -1992,18 +1992,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionCODE8883E38D": Object {
+    "SubscriptionCODEuswest176FCF696": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
         "Region": "us-west-1",
         "TopicArn": Object {
-          "Ref": "TopicCODEA0288998",
+          "Ref": "TopicCODEuswest1BCC7F1D9",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicCODEA0288998": Object {
+    "TopicCODEuswest1BCC7F1D9": Object {
       "Properties": Object {
         "Tags": Array [
           Object {
@@ -2048,11 +2048,11 @@ Object {
         "ActionsEnabled": true,
         "AlarmActions": Array [
           Object {
-            "Ref": "TopicPROD02C7A195",
+            "Ref": "TopicPRODuswest13F6F85C0",
           },
         ],
-        "AlarmDescription": "Either a Front or an Article CMP has failed",
-        "AlarmName": "commercial-canary-PROD",
+        "AlarmDescription": "Either a Front or an Article CMP has failed in us-west-1",
+        "AlarmName": "commercial-canary-PROD-us-west-1",
         "ComparisonOperator": "LessThanOrEqualToThreshold",
         "DatapointsToAlarm": 5,
         "Dimensions": Array [
@@ -2066,7 +2066,7 @@ Object {
         "Namespace": "CloudWatchSynthetics",
         "OKActions": Array [
           Object {
-            "Ref": "TopicPROD02C7A195",
+            "Ref": "TopicPRODuswest13F6F85C0",
           },
         ],
         "Period": 60,
@@ -2282,18 +2282,18 @@ Object {
       },
       "Type": "AWS::IAM::Role",
     },
-    "SubscriptionPROD6213BADC": Object {
+    "SubscriptionPRODuswest1F1008298": Object {
       "Properties": Object {
         "Endpoint": "commercial.canaries@guardian.co.uk",
         "Protocol": "email",
         "Region": "us-west-1",
         "TopicArn": Object {
-          "Ref": "TopicPROD02C7A195",
+          "Ref": "TopicPRODuswest13F6F85C0",
         },
       },
       "Type": "AWS::SNS::Subscription",
     },
-    "TopicPROD02C7A195": Object {
+    "TopicPRODuswest13F6F85C0": Object {
       "Properties": Object {
         "Tags": Array [
           Object {

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -137,20 +137,20 @@ export class CommercialCanaries extends GuStack {
 			],
 		});
 
-		// if (stage === 'PROD') {
-		const topic = new Topic(this, `Topic-${stage}-${env.region}`);
+		const topic = new Topic(this, 'Topic');
 
-		new Subscription(this, `Subscription-${stage}-${env.region}`, {
+		new Subscription(this, 'Subscription', {
 			topic,
 			endpoint: `commercial.canaries+${stage}-${env.region}@guardian.co.uk`,
 			protocol: SubscriptionProtocol.EMAIL,
 			region: env.region,
 		});
 
-		const alarm = new Alarm(this, `Alarm-${stage}`, {
+		// if (stage === 'PROD') {
+		const alarm = new Alarm(this, 'Alarm', {
 			actionsEnabled: true,
 			alarmDescription: `Either a Front or an Article CMP has failed in ${env.region}`,
-			alarmName: `commercial-canary-${stage}-${env.region}`,
+			alarmName: `commercial-canary-${stage}`,
 			comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
 			datapointsToAlarm: 5,
 			evaluationPeriods: 5,

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -139,9 +139,9 @@ export class CommercialCanaries extends GuStack {
 		});
 
 		// if (stage === 'PROD') {
-		const topic = new Topic(this, `Topic-${stage}`);
+		const topic = new Topic(this, `Topic-${stage}-${env.region}`);
 
-		new Subscription(this, `Subscription-${stage}`, {
+		new Subscription(this, `Subscription-${stage}-${env.region}`, {
 			topic,
 			endpoint: email,
 			protocol: SubscriptionProtocol.EMAIL,
@@ -150,8 +150,8 @@ export class CommercialCanaries extends GuStack {
 
 		const alarm = new Alarm(this, `Alarm-${stage}`, {
 			actionsEnabled: true,
-			alarmDescription: 'Either a Front or an Article CMP has failed',
-			alarmName: `commercial-canary-${stage}`,
+			alarmDescription: `Either a Front or an Article CMP has failed in ${env.region}`,
+			alarmName: `commercial-canary-${stage}-${env.region}`,
 			comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
 			datapointsToAlarm: 5,
 			evaluationPeriods: 5,

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -145,6 +145,7 @@ export class CommercialCanaries extends GuStack {
 			topic,
 			endpoint: email,
 			protocol: SubscriptionProtocol.EMAIL,
+			region: env.region,
 		});
 
 		const alarm = new Alarm(this, `Alarm-${stage}`, {

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -138,36 +138,37 @@ export class CommercialCanaries extends GuStack {
 			],
 		});
 
-		// if (stage === 'PROD') {
-		const topic = new Topic(this, 'Topic');
+		if (stage === 'PROD') {
+			const topic = new Topic(this, `Topic-${stage}`);
 
-		new Subscription(this, 'Subscription', {
-			topic,
-			endpoint: email,
-			protocol: SubscriptionProtocol.EMAIL,
-		});
+			new Subscription(this, `Subscription-${stage}`, {
+				topic,
+				endpoint: email,
+				protocol: SubscriptionProtocol.EMAIL,
+			});
 
-		const alarm = new Alarm(this, `Alarm`, {
-			actionsEnabled: true,
-			alarmDescription: 'Either a Front or an Article CMP has failed',
-			alarmName: `Commercial canary`,
-			comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-			datapointsToAlarm: 5,
-			evaluationPeriods: 5,
-			metric: new Metric({
-				namespace: 'CloudWatchSynthetics',
-				metricName: 'SuccessPercent',
-				statistic: 'avg',
-				period: Duration.minutes(1),
-				dimensionsMap: {
-					CanaryName: canaryName,
-				},
-			}),
-			threshold: 80,
-			treatMissingData: TreatMissingData.BREACHING,
-		});
+			const alarm = new Alarm(this, `Alarm-${stage}`, {
+				actionsEnabled: true,
+				alarmDescription: 'Either a Front or an Article CMP has failed',
+				alarmName: `commercial-canary-${stage}`,
+				comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+				datapointsToAlarm: 5,
+				evaluationPeriods: 5,
+				metric: new Metric({
+					namespace: 'CloudWatchSynthetics',
+					metricName: 'SuccessPercent',
+					statistic: 'avg',
+					period: Duration.minutes(1),
+					dimensionsMap: {
+						CanaryName: canaryName,
+					},
+				}),
+				threshold: 80,
+				treatMissingData: TreatMissingData.BREACHING,
+			});
 
-		alarm.addAlarmAction(new SnsAction(topic));
+			alarm.addAlarmAction(new SnsAction(topic));
+			alarm.addOkAction(new SnsAction(topic));
+		}
 	}
 }
-// }

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -146,29 +146,29 @@ export class CommercialCanaries extends GuStack {
 			region: env.region,
 		});
 
-		// if (stage === 'PROD') {
-		const alarm = new Alarm(this, 'Alarm', {
-			actionsEnabled: true,
-			alarmDescription: `Either a Front or an Article CMP has failed in ${env.region}`,
-			alarmName: `commercial-canary-${stage}`,
-			comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-			datapointsToAlarm: 5,
-			evaluationPeriods: 5,
-			metric: new Metric({
-				namespace: 'CloudWatchSynthetics',
-				metricName: 'SuccessPercent',
-				statistic: 'avg',
-				period: Duration.minutes(1),
-				dimensionsMap: {
-					CanaryName: canaryName,
-				},
-			}),
-			threshold: 80,
-			treatMissingData: TreatMissingData.BREACHING,
-		});
+		if (stage === 'PROD') {
+			const alarm = new Alarm(this, 'Alarm', {
+				actionsEnabled: true,
+				alarmDescription: `Either a Front or an Article CMP has failed in ${env.region}`,
+				alarmName: `commercial-canary-${stage}`,
+				comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+				datapointsToAlarm: 5,
+				evaluationPeriods: 5,
+				metric: new Metric({
+					namespace: 'CloudWatchSynthetics',
+					metricName: 'SuccessPercent',
+					statistic: 'avg',
+					period: Duration.minutes(1),
+					dimensionsMap: {
+						CanaryName: canaryName,
+					},
+				}),
+				threshold: 80,
+				treatMissingData: TreatMissingData.BREACHING,
+			});
 
-		alarm.addAlarmAction(new SnsAction(topic));
-		alarm.addOkAction(new SnsAction(topic));
+			alarm.addAlarmAction(new SnsAction(topic));
+			alarm.addOkAction(new SnsAction(topic));
+		}
 	}
 }
-// }

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -138,37 +138,37 @@ export class CommercialCanaries extends GuStack {
 			],
 		});
 
-		if (stage === 'PROD') {
-			const topic = new Topic(this, `Topic-${stage}`);
+		// if (stage === 'PROD') {
+		const topic = new Topic(this, `Topic-${stage}`);
 
-			new Subscription(this, `Subscription-${stage}`, {
-				topic,
-				endpoint: email,
-				protocol: SubscriptionProtocol.EMAIL,
-			});
+		new Subscription(this, `Subscription-${stage}`, {
+			topic,
+			endpoint: email,
+			protocol: SubscriptionProtocol.EMAIL,
+		});
 
-			const alarm = new Alarm(this, `Alarm-${stage}`, {
-				actionsEnabled: true,
-				alarmDescription: 'Either a Front or an Article CMP has failed',
-				alarmName: `commercial-canary-${stage}`,
-				comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
-				datapointsToAlarm: 5,
-				evaluationPeriods: 5,
-				metric: new Metric({
-					namespace: 'CloudWatchSynthetics',
-					metricName: 'SuccessPercent',
-					statistic: 'avg',
-					period: Duration.minutes(1),
-					dimensionsMap: {
-						CanaryName: canaryName,
-					},
-				}),
-				threshold: 80,
-				treatMissingData: TreatMissingData.BREACHING,
-			});
+		const alarm = new Alarm(this, `Alarm-${stage}`, {
+			actionsEnabled: true,
+			alarmDescription: 'Either a Front or an Article CMP has failed',
+			alarmName: `commercial-canary-${stage}`,
+			comparisonOperator: ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+			datapointsToAlarm: 5,
+			evaluationPeriods: 5,
+			metric: new Metric({
+				namespace: 'CloudWatchSynthetics',
+				metricName: 'SuccessPercent',
+				statistic: 'avg',
+				period: Duration.minutes(1),
+				dimensionsMap: {
+					CanaryName: canaryName,
+				},
+			}),
+			threshold: 80,
+			treatMissingData: TreatMissingData.BREACHING,
+		});
 
-			alarm.addAlarmAction(new SnsAction(topic));
-			alarm.addOkAction(new SnsAction(topic));
-		}
+		alarm.addAlarmAction(new SnsAction(topic));
+		alarm.addOkAction(new SnsAction(topic));
 	}
 }
+// }

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -146,6 +146,7 @@ export class CommercialCanaries extends GuStack {
 			region: env.region,
 		});
 
+		// We add the alarm only for PROD but it's easier to keep the topic and subscription in both stages.
 		if (stage === 'PROD') {
 			const alarm = new Alarm(this, 'Alarm', {
 				actionsEnabled: true,

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -28,7 +28,6 @@ export class CommercialCanaries extends GuStack {
 			throw new Error('env.region is required');
 		}
 
-		const email = 'commercial.canaries@guardian.co.uk';
 		const accountId = this.account;
 		const S3BucketCanary = `cw-syn-canary-${accountId}-${env.region}`;
 		const S3BucketResults = `cw-syn-results-${accountId}-${env.region}`;
@@ -143,7 +142,7 @@ export class CommercialCanaries extends GuStack {
 
 		new Subscription(this, `Subscription-${stage}-${env.region}`, {
 			topic,
-			endpoint: email,
+			endpoint: `commercial.canaries+${stage}-${env.region}@guardian.co.uk`,
 			protocol: SubscriptionProtocol.EMAIL,
 			region: env.region,
 		});

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc",
-    "test": "jest",
+    "test": "jest --verbose",
+    "test-update": "jest -u",
     "format": "prettier --write \"{lib,bin}/**/*.ts\"",
     "lint": "eslint lib/** bin/** --ext .ts --no-error-on-unmatched-pattern",
     "synth": "cdk synth --path-metadata false --version-reporting false",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR fixes the email subscription alert that wasn't working when CloudWatch is in the `ALARM` state for `us-west-1`, `ca-central-1` and `ep-southeast-2`. It was only working for `eu-west-1`. 

The solution is still a mystery which is adding an alias to the Subscription email endpoint for each region.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

If you check the AWS Topic in commercial-canaries CODE for each region you will find the subscription associated with it has a _Status_ `confirmed`. There is no way to test it in PROD until we merge this PR and we should receive new Subscription confirmation emails for each region. For testing our changes in PROD we can trigger the `ALARM` state in any of the previously non working regions to make sure it works!

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We get notified through email alerts for any of the specified regions whenever the CloudWatch alarm is in the `ALARM` state.


