### PR TITLE
Update version of syn-nodejs-puppeteer

### DIFF
--- a/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
+++ b/cdk/lib/__snapshots__/commercial-canaries.test.ts.snap
@@ -56,7 +56,7 @@ exports[`The CommercialCanaries stack matches the Australia CODE snapshot 1`] = 
           "MemoryInMB": 3008,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-7.0",
+        "RuntimeVersion": "syn-nodejs-puppeteer-9.1",
         "Schedule": {
           "DurationInSeconds": "1800",
           "Expression": "rate(1 minute)",
@@ -379,7 +379,7 @@ exports[`The CommercialCanaries stack matches the Australia PROD snapshot 1`] = 
           "MemoryInMB": 3008,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-7.0",
+        "RuntimeVersion": "syn-nodejs-puppeteer-9.1",
         "Schedule": {
           "DurationInSeconds": "0",
           "Expression": "rate(1 minute)",
@@ -636,7 +636,7 @@ exports[`The CommercialCanaries stack matches the Canada CODE snapshot 1`] = `
           "MemoryInMB": 2048,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-7.0",
+        "RuntimeVersion": "syn-nodejs-puppeteer-9.1",
         "Schedule": {
           "DurationInSeconds": "1800",
           "Expression": "rate(1 minute)",
@@ -959,7 +959,7 @@ exports[`The CommercialCanaries stack matches the Canada PROD snapshot 1`] = `
           "MemoryInMB": 2048,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-7.0",
+        "RuntimeVersion": "syn-nodejs-puppeteer-9.1",
         "Schedule": {
           "DurationInSeconds": "0",
           "Expression": "rate(1 minute)",
@@ -1216,7 +1216,7 @@ exports[`The CommercialCanaries stack matches the Europe CODE snapshot 1`] = `
           "MemoryInMB": 2048,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-7.0",
+        "RuntimeVersion": "syn-nodejs-puppeteer-9.1",
         "Schedule": {
           "DurationInSeconds": "1800",
           "Expression": "rate(1 minute)",
@@ -1539,7 +1539,7 @@ exports[`The CommercialCanaries stack matches the Europe PROD snapshot 1`] = `
           "MemoryInMB": 2048,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-7.0",
+        "RuntimeVersion": "syn-nodejs-puppeteer-9.1",
         "Schedule": {
           "DurationInSeconds": "0",
           "Expression": "rate(1 minute)",
@@ -1796,7 +1796,7 @@ exports[`The CommercialCanaries stack matches the US CODE snapshot 1`] = `
           "MemoryInMB": 3008,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-7.0",
+        "RuntimeVersion": "syn-nodejs-puppeteer-9.1",
         "Schedule": {
           "DurationInSeconds": "1800",
           "Expression": "rate(1 minute)",
@@ -2119,7 +2119,7 @@ exports[`The CommercialCanaries stack matches the US PROD snapshot 1`] = `
           "MemoryInMB": 3008,
           "TimeoutInSeconds": 60,
         },
-        "RuntimeVersion": "syn-nodejs-puppeteer-7.0",
+        "RuntimeVersion": "syn-nodejs-puppeteer-9.1",
         "Schedule": {
           "DurationInSeconds": "0",
           "Expression": "rate(1 minute)",

--- a/cdk/lib/commercial-canaries.ts
+++ b/cdk/lib/commercial-canaries.ts
@@ -117,7 +117,7 @@ export class CommercialCanaries extends GuStack {
 			},
 			executionRoleArn: role.roleArn,
 			name: canaryName,
-			runtimeVersion: 'syn-nodejs-puppeteer-7.0',
+			runtimeVersion: 'syn-nodejs-puppeteer-9.1',
 			runConfig: {
 				timeoutInSeconds: 60,
 				memoryInMb: isTcf ? 2048 : 3008,

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -1,4 +1,3 @@
-const { URL } = require('url');
 const synthetics = require('Synthetics');
 const logger = require('SyntheticsLogger');
 
@@ -64,11 +63,9 @@ const interactWithCMP = async (page) => {
 	// When AWS Synthetics use a more up-to-date version of Puppeteer, we can make use of waitForFrame()
 	log(`Clicking on "Continue" on CMP`);
 
-	const frame = page.frames().find((f) => {
-		const parsedUrl = new URL(f.url());
-		return parsedUrl.host === 'sourcepoint.theguardian.com';
-	});
-	await frame.click('button[title="Continue"]');
+	const iframeElementHandle = await page.$('iframe[id*="sp_message_iframe"]');
+	const iframe = await iframeElementHandle.contentFrame();
+	await iframe.click('button[title="Continue"]');
 };
 
 const checkCMPIsOnPage = async (page) => {

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -113,6 +113,9 @@ const reloadPage = async (page) => {
 		throw 'Failed to refresh page!';
 	}
 
+	// We see some run failures if we do not include a wait time after a page reload
+	await new Promise((r) => setTimeout(r, 3000));
+
 	log(`Reloading page: Complete`);
 };
 
@@ -260,6 +263,9 @@ const loadPage = async (page, url) => {
 		logError(`Loading page: Failed. Status code: ${response.status()}`);
 		throw 'Failed to load page!';
 	}
+
+	// We see some run failures if we do not include a wait time after a page load
+	await new Promise((r) => setTimeout(r, 3000));
 
 	log(`Loading page: Complete`);
 };

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -33,6 +33,14 @@ const clearLocalStorage = async (page) => {
 	log(`Cleared local storage`);
 };
 
+const setAdTestCookie = async (page) => {
+	await page.setCookie({
+		name: 'adtest',
+		value: 'fixed-puppies-ci',
+		domain: '.theguardian.com',
+	});
+};
+
 const checkTopAdHasLoaded = async (page) => {
 	log(`Waiting for ads to load: Start`);
 	try {
@@ -273,6 +281,7 @@ const checkPage = async (pageType, url) => {
 	await loadPage(page, url);
 	await clearLocalStorage(page);
 	await clearCookies(page);
+	await setAdTestCookie(page);
 
 	// Now we can run our tests.
 	log(`[TEST 1] start: Adverts load and the CMP is displayed on initial load`);
@@ -302,6 +311,7 @@ const checkPage = async (pageType, url) => {
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
+	await setAdTestCookie(page);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -108,9 +108,6 @@ const reloadPage = async (page) => {
 		throw 'Failed to refresh page!';
 	}
 
-	// We see some run failures if we do not include a wait time after a page reload
-	await page.waitForTimeout(3000);
-
 	log(`Reloading page: Complete`);
 };
 
@@ -258,9 +255,6 @@ const loadPage = async (page, url) => {
 		logError(`Loading page: Failed. Status code: ${response.status()}`);
 		throw 'Failed to load page!';
 	}
-
-	// We see some run failures if we do not include a wait time after a page load
-	await page.waitForTimeout(3000);
 
 	log(`Loading page: Complete`);
 };

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -34,6 +34,14 @@ const clearLocalStorage = async (page) => {
 	log(`Cleared local storage`);
 };
 
+const setAdTestCookie = async (page) => {
+	await page.setCookie({
+		name: 'adtest',
+		value: 'fixed-puppies-ci',
+		domain: '.theguardian.com',
+	});
+};
+
 const checkTopAdHasLoaded = async (page) => {
 	log(`Waiting for ads to load: Start`);
 	try {
@@ -287,6 +295,7 @@ const checkPage = async (pageType, url) => {
 	await loadPage(page, url);
 	await clearLocalStorage(page);
 	await clearCookies(page);
+	await setAdTestCookie(page);
 
 	// Now we can run our tests.
 	log(`[TEST 1] start: Adverts load and the CMP is displayed on initial load`);
@@ -313,6 +322,7 @@ const checkPage = async (pageType, url) => {
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
+	await setAdTestCookie(page);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -1,4 +1,3 @@
-const { URL } = require('url');
 const synthetics = require('Synthetics');
 const logger = require('SyntheticsLogger');
 
@@ -64,17 +63,15 @@ const checkTopAdHasLoaded = async (page) => {
 const interactWithCMP = async (page) => {
 	// When AWS Synthetics use a more up-to-date version of Puppeteer, we can make use of waitForFrame()
 	log(`Clicking on "Do not sell or share my personal information" on CMP`);
-	const frame = page.frames().find((f) => {
-		const parsedUrl = new URL(f.url());
-		return parsedUrl.host === 'sourcepoint.theguardian.com';
-	});
+	const iframeElementHandle = await page.$('iframe[id*="sp_message_iframe"]');
+	const iframe = await iframeElementHandle.contentFrame();
 
-	if (frame) {
-		await frame.waitForSelector(
+	if (iframe) {
+		await iframe.waitForSelector(
 			'button[title="Do not sell or share my personal information"]',
 			{ timeout: 5000 },
 		);
-		await frame.click(
+		await iframe.click(
 			'button[title="Do not sell or share my personal information"]',
 		);
 	} else {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -255,6 +255,9 @@ const reloadPage = async (page) => {
 		throw 'Failed to refresh page!';
 	}
 
+	// We see some run failures if we do not include a wait time after a page reload
+	await new Promise((r) => setTimeout(r, 3000));
+
 	log(`Reloading page: Complete`);
 };
 
@@ -274,6 +277,9 @@ const loadPage = async (page, url) => {
 		logError(`Loading page: Failed. Status code: ${response.status()}`);
 		throw 'Failed to load page!';
 	}
+
+	// We see some run failures if we do not include a wait time after a page load
+	await new Promise((r) => setTimeout(r, 3000));
 
 	log(`Loading page: Complete`);
 };

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -74,8 +74,6 @@ const interactWithCMP = async (page) => {
 	}
 
 	await page.waitForNavigation({ waitUntil: 'domcontentloaded' });
-	// We see some run failures if we do not include a wait time after a page load
-	await page.waitForTimeout(3000);
 };
 
 const checkCMPIsOnPage = async (page) => {
@@ -252,9 +250,6 @@ const reloadPage = async (page) => {
 		throw 'Failed to refresh page!';
 	}
 
-	// We see some run failures if we do not include a wait time after a page reload
-	await page.waitForTimeout(3000);
-
 	log(`Reloading page: Complete`);
 };
 
@@ -274,9 +269,6 @@ const loadPage = async (page, url) => {
 		logError(`Loading page: Failed. Status code: ${response.status()}`);
 		throw 'Failed to load page!';
 	}
-
-	// We see some run failures if we do not include a wait time after a page load
-	await page.waitForTimeout(3000);
 
 	log(`Loading page: Complete`);
 };

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -32,6 +32,14 @@ const clearLocalStorage = async (page) => {
 	log(`Cleared local storage`);
 };
 
+const setAdTestCookie = async (page) => {
+	await page.setCookie({
+		name: 'adtest',
+		value: 'fixed-puppies-ci',
+		domain: '.theguardian.com',
+	});
+};
+
 const checkTopAdHasLoaded = async (page) => {
 	log(`Waiting for ads to load: Start`);
 	try {
@@ -310,6 +318,7 @@ const checkPage = async (pageType, url) => {
 	await loadPage(page, url);
 	await clearLocalStorage(page);
 	await clearCookies(page);
+	await setAdTestCookie(page);
 
 	// Now we can run our tests.
 	log(
@@ -350,6 +359,7 @@ const checkPage = async (pageType, url) => {
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
+	await setAdTestCookie(page);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -130,6 +130,9 @@ const reloadPage = async (page) => {
 		throw 'Failed to refresh page!';
 	}
 
+	// We see some run failures if we do not include a wait time after a page reload
+	await new Promise((r) => setTimeout(r, 3000));
+
 	log(`Reloading page: Complete`);
 };
 
@@ -149,6 +152,9 @@ const loadPage = async (page, url) => {
 		logError(`Loading page: Failed. Status code: ${response.status()}`);
 		throw 'Failed to load page!';
 	}
+
+	// We see some run failures if we do not include a wait time after a page load
+	await new Promise((r) => setTimeout(r, 3000));
 
 	log(`Loading page: Complete`);
 };

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -126,9 +126,6 @@ const reloadPage = async (page) => {
 		throw 'Failed to refresh page!';
 	}
 
-	// We see some run failures if we do not include a wait time after a page load
-	await page.waitForTimeout(3000);
-
 	log(`Reloading page: Complete`);
 };
 
@@ -148,9 +145,6 @@ const loadPage = async (page, url) => {
 		logError(`Loading page: Failed. Status code: ${response.status()}`);
 		throw 'Failed to load page!';
 	}
-
-	// We see some run failures if we do not include a wait time after a page reload
-	await page.waitForTimeout(3000);
 
 	log(`Loading page: Complete`);
 };

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -1,4 +1,3 @@
-const { URL } = require('url');
 const synthetics = require('Synthetics');
 const logger = require('SyntheticsLogger');
 
@@ -68,17 +67,14 @@ const checkTopAdDidNotLoad = async (page) => {
 };
 
 const interactWithCMP = async (page) => {
-	// When AWS Synthetics use a more up-to-date version of Puppeteer, we can make use of waitForFrame()
-	log(`Clicking on "Yes I'm Happy"`);
-	const frame = page.frames().find((f) => {
-		const parsedUrl = new URL(f.url());
-		return parsedUrl.host === 'sourcepoint.theguardian.com';
-	});
+	log(`Clicking on "Accept All"`);
 
-	// Accept cookies
-	await frame.click(
-		'div.message-component.message-row > button.btn-primary.sp_choice_type_11',
-	);
+	const iframeElementHandle = await page.$('iframe[id*="sp_message_iframe"]');
+	const iframe = await iframeElementHandle.contentFrame();
+
+	await iframe.evaluate(() => {
+		document.querySelector('button.btn-primary.sp_choice_type_11').click();
+	});
 };
 
 const checkCMPIsOnPage = async (page) => {


### PR DESCRIPTION
## What are you changing?
Updates the version of `syn-nodejs-puppeteer` to 9.1. I had to make a few updates as a result of some deprecations in the bumped puppeteer version:

- `waitForTimeout` is now deprecated, so I've just deleted all references to it. Everything seems to be broadly fine still!
- I also noticed that the adtest cookie being set in the URL was being immediately cleared by `clearCookies` being called after `loadPage`. I've added a `setAdTestCookie` function which makes sure the adtest cookie is re set, and should significantly reduce flakiness, as the ad selectors depend on the puppies ads pulling through
- I've also updated the way we select the CMP iframe - I was getting errors and timeouts when filtering the iframes by host URL - selecting using ID seems to be less flaky, and also aligns the logic to be the same selectors that we use in our commercial Playwright testing

## Why?
The current version is using a Node.js 18.x runtime, which is being deprecated in October. Updating the version now will remove the issue in the AWS account health dashboard.