### PR TITLE
Make sure ad test cookie is re-set after cookies are cleared

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -33,6 +33,14 @@ const clearLocalStorage = async (page) => {
 	log(`Cleared local storage`);
 };
 
+const setAdTestCookie = async (page) => {
+	await page.setCookie({
+		name: 'adtest',
+		value: 'fixed-puppies-ci',
+		domain: '.theguardian.com',
+	});
+};
+
 const checkTopAdHasLoaded = async (page) => {
 	log(`Waiting for ads to load: Start`);
 	try {
@@ -279,6 +287,7 @@ const checkPage = async (pageType, url) => {
 	await loadPage(page, url);
 	await clearLocalStorage(page);
 	await clearCookies(page);
+	await setAdTestCookie(page);
 
 	// Now we can run our tests.
 	log(`[TEST 1] start: Adverts load and the CMP is displayed on initial load`);
@@ -308,6 +317,7 @@ const checkPage = async (pageType, url) => {
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
+	await setAdTestCookie(page);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -317,7 +317,6 @@ const checkPage = async (pageType, url) => {
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
-	await setAdTestCookie(page);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -34,6 +34,14 @@ const clearLocalStorage = async (page) => {
 	log(`Cleared local storage`);
 };
 
+const setAdTestCookie = async (page) => {
+	await page.setCookie({
+		name: 'adtest',
+		value: 'fixed-puppies-ci',
+		domain: '.theguardian.com',
+	});
+};
+
 const checkTopAdHasLoaded = async (page) => {
 	log(`Waiting for ads to load: Start`);
 	try {
@@ -295,6 +303,7 @@ const checkPage = async (pageType, url) => {
 	await loadPage(page, url);
 	await clearLocalStorage(page);
 	await clearCookies(page);
+	await setAdTestCookie(page);
 
 	// Now we can run our tests.
 	log(`[TEST 1] start: Adverts load and the CMP is displayed on initial load`);
@@ -321,6 +330,7 @@ const checkPage = async (pageType, url) => {
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
+	await setAdTestCookie(page);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -330,7 +330,6 @@ const checkPage = async (pageType, url) => {
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
-	await setAdTestCookie(page);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -33,6 +33,14 @@ const clearLocalStorage = async (page) => {
 	log(`Cleared local storage`);
 };
 
+const setAdTestCookie = async (page) => {
+	await page.setCookie({
+		name: 'adtest',
+		value: 'fixed-puppies-ci',
+		domain: '.theguardian.com',
+	});
+};
+
 const checkTopAdHasLoaded = async (page) => {
 	log(`Waiting for ads to load: Start`);
 	try {
@@ -320,6 +328,7 @@ const checkPage = async (pageType, url) => {
 	await loadPage(page, url);
 	await clearLocalStorage(page);
 	await clearCookies(page);
+	await setAdTestCookie(page);
 
 	// Now we can run our tests.
 	log(
@@ -360,6 +369,7 @@ const checkPage = async (pageType, url) => {
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
+	await setAdTestCookie(page);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -369,7 +369,6 @@ const checkPage = async (pageType, url) => {
 	);
 	await clearLocalStorage(page);
 	await clearCookies(page);
-	await setAdTestCookie(page);
 	await reloadPage(page);
 	await synthetics.takeScreenshot(
 		`${pageType}-page`,


### PR DESCRIPTION
## What are you changing?
Makes sure that the puppies ad test cookie is set before the canaries start testing.

## Why?
At the moment we set the ad test cookie in the URL of the initial page load, but then use a function to clear all cookies before the test starts. This means some test failures can be caused by the puppies ads not being on the page as the ad test cookie is not present, and the ad selectors we use to check for top-above-nav are different for the puppies ads.



