### PR TITLE
Move shared functions into utils

### DIFF
--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -1,37 +1,9 @@
 const { URL } = require('url');
 const synthetics = require('Synthetics');
-const logger = require('SyntheticsLogger');
+const { log, logError, clearCookies, clearLocalStorage } = require('./utils');
 
 const LOG_EVERY_REQUEST = false;
 const LOG_EVERY_RESPONSE = false;
-
-let startTime = new Date().getTime();
-const getTimeSinceStart = () => new Date().getTime() - startTime;
-
-/**
- * We use custom log messages so that we can easily differentiate
- * between logs from this file and other logs in Cloudwatch.
- */
-const formatMessage = (message) =>
-	`GuCanaryRun. Time: ${getTimeSinceStart() / 1000}s. Message: ${message}`;
-
-const log = (message) => {
-	logger.info(formatMessage(message));
-};
-const logError = (message) => {
-	logger.error(formatMessage(message));
-};
-
-const clearCookies = async (page) => {
-	const allCookies = await page.cookies();
-	await page.deleteCookie(...allCookies);
-	log(`Cleared Cookies`);
-};
-
-const clearLocalStorage = async (page) => {
-	await page.evaluate(() => localStorage.clear());
-	log(`Cleared local storage`);
-};
 
 const checkTopAdHasLoaded = async (page) => {
 	log(`Waiting for ads to load: Start`);

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -8,6 +8,8 @@ const {
 	checkTopAdHasLoaded,
 	checkCMPIsOnPage,
 	checkCMPIsNotVisible,
+	loadPage,
+	reloadPage,
 } = require('./utils');
 
 const LOG_EVERY_REQUEST = false;
@@ -22,23 +24,6 @@ const interactWithCMP = async (page) => {
 		return parsedUrl.host === 'sourcepoint.theguardian.com';
 	});
 	await frame.click('button[title="Continue"]');
-};
-
-const reloadPage = async (page) => {
-	log(`Reloading page: Start`);
-	const reloadResponse = await page.reload({
-		waitUntil: 'domcontentloaded',
-		timeout: 30000,
-	});
-	if (!reloadResponse) {
-		logError(`Reloading page: Failed`);
-		throw 'Failed to refresh page!';
-	}
-
-	// We see some run failures if we do not include a wait time after a page reload
-	await page.waitForTimeout(3000);
-
-	log(`Reloading page: Complete`);
 };
 
 const checkPrebid = async (page) => {
@@ -169,29 +154,6 @@ const checkPrebid = async (page) => {
 	// --------------- BID RESPONSE END ---------------------------
 };
 
-const loadPage = async (page, url) => {
-	log(`Loading page: Start`);
-	const response = await page.goto(url, {
-		waitUntil: 'domcontentloaded',
-		timeout: 30000,
-	});
-	if (!response) {
-		logError('Loading page: Failed');
-		throw 'Failed to load page!';
-	}
-
-	// If the response status code is not a 2xx success code
-	if (response.status() < 200 || response.status() > 299) {
-		logError(`Loading page: Failed. Status code: ${response.status()}`);
-		throw 'Failed to load page!';
-	}
-
-	// We see some run failures if we do not include a wait time after a page load
-	await page.waitForTimeout(3000);
-
-	log(`Loading page: Complete`);
-};
-
 /**
  * Checks that ads load correctly for the first time a user goes to
  * the site, with respect to and interaction with the CMP.
@@ -268,8 +230,6 @@ const pageLoadBlueprint = async function () {
 		screenshotOnStepSuccess: false,
 		screenshotOnStepFailure: true,
 	});
-
-	startTime = new Date().getTime();
 
 	// The query param "adtest=fixed-puppies-ci" is used to ensure that GAM provides us with an ad for our slot
 	await synthetics.executeStep('Test Front page', async function () {

--- a/src/cmp_aus.js
+++ b/src/cmp_aus.js
@@ -1,28 +1,17 @@
 const { URL } = require('url');
 const synthetics = require('Synthetics');
-const { log, logError, clearCookies, clearLocalStorage } = require('./utils');
+const {
+	log,
+	logError,
+	clearCookies,
+	clearLocalStorage,
+	checkTopAdHasLoaded,
+	checkCMPIsOnPage,
+	checkCMPIsNotVisible,
+} = require('./utils');
 
 const LOG_EVERY_REQUEST = false;
 const LOG_EVERY_RESPONSE = false;
-
-const checkTopAdHasLoaded = async (page) => {
-	log(`Waiting for ads to load: Start`);
-	try {
-		await page.waitForSelector(
-			'.ad-slot--top-above-nav .ad-slot__content iframe',
-			{ timeout: 30000 },
-		);
-	} catch (e) {
-		logError(`Failed to load top-above-nav ad: ${e.message}`);
-		await synthetics.takeScreenshot(
-			`${page}-page`,
-			'Failed to load top-above-nav ad',
-		);
-		throw new Error('top-above-nav ad did not load');
-	}
-
-	log(`Waiting for ads to load: Complete`);
-};
 
 const interactWithCMP = async (page) => {
 	// When AWS Synthetics use a more up-to-date version of Puppeteer, we can make use of waitForFrame()
@@ -33,40 +22,6 @@ const interactWithCMP = async (page) => {
 		return parsedUrl.host === 'sourcepoint.theguardian.com';
 	});
 	await frame.click('button[title="Continue"]');
-};
-
-const checkCMPIsOnPage = async (page) => {
-	log(`Waiting for CMP: Start`);
-	try {
-		await page.waitForSelector('[id*="sp_message_container"]');
-	} catch (e) {
-		logError(`Could not find CMP: ${e.message}`);
-		await synthetics.takeScreenshot(`${page}-page`, 'Could not find CMP');
-		throw new Error('top-above-nav ad did not load');
-	}
-
-	log(`Waiting for CMP: Finish`);
-};
-
-const checkCMPIsNotVisible = async (page) => {
-	log(`Checking CMP is Hidden: Start`);
-
-	const getSpMessageDisplayProperty = function () {
-		const element = document.querySelector('[id*="sp_message_container"]');
-		if (element) {
-			const computedStyle = window.getComputedStyle(element);
-			return computedStyle.getPropertyValue('display');
-		}
-	};
-
-	const display = await page.evaluate(getSpMessageDisplayProperty);
-
-	// Use `!=` rather than `!==` here because display is a DOMString type
-	if (display && display != 'none') {
-		throw Error('CMP still present on page');
-	}
-
-	log('CMP hidden or removed from page');
 };
 
 const reloadPage = async (page) => {

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -1,38 +1,9 @@
 const { URL } = require('url');
 const synthetics = require('Synthetics');
-const logger = require('SyntheticsLogger');
+const { log, logError, clearCookies, clearLocalStorage } = require('./utils');
 
 const LOG_EVERY_REQUEST = false;
 const LOG_EVERY_RESPONSE = false;
-
-let startTime = new Date().getTime();
-const getTimeSinceStart = () => new Date().getTime() - startTime;
-
-/**
- * We use custom log messages so that we can easily differentiate
- * between logs from this file and other logs in Cloudwatch.
- *
- */
-const formatMessage = (message) =>
-	`GuCanaryRun. Time: ${getTimeSinceStart() / 1000}s. Message: ${message}`;
-
-const log = (message) => {
-	logger.info(formatMessage(message));
-};
-const logError = (message) => {
-	logger.error(formatMessage(message));
-};
-
-const clearCookies = async (page) => {
-	const allCookies = await page.cookies();
-	await page.deleteCookie(...allCookies);
-	log(`Cleared Cookies`);
-};
-
-const clearLocalStorage = async (page) => {
-	await page.evaluate(() => localStorage.clear());
-	log(`Cleared local storage`);
-};
 
 const checkTopAdHasLoaded = async (page) => {
 	log(`Waiting for ads to load: Start`);

--- a/src/cmp_ccpa.js
+++ b/src/cmp_ccpa.js
@@ -8,6 +8,8 @@ const {
 	checkTopAdHasLoaded,
 	checkCMPIsOnPage,
 	checkCMPIsNotVisible,
+	loadPage,
+	reloadPage,
 } = require('./utils');
 
 const LOG_EVERY_REQUEST = false;
@@ -167,46 +169,6 @@ const checkPrebid = async (page) => {
 	// --------------- BID RESPONSE END ---------------------------
 };
 
-const reloadPage = async (page) => {
-	log(`Reloading page: Start`);
-	const reloadResponse = await page.reload({
-		waitUntil: 'domcontentloaded',
-		timeout: 30000,
-	});
-	if (!reloadResponse) {
-		logError(`Reloading page: Failed`);
-		throw 'Failed to refresh page!';
-	}
-
-	// We see some run failures if we do not include a wait time after a page reload
-	await page.waitForTimeout(3000);
-
-	log(`Reloading page: Complete`);
-};
-
-const loadPage = async (page, url) => {
-	log(`Loading page: Start`);
-	const response = await page.goto(url, {
-		waitUntil: 'domcontentloaded',
-		timeout: 30000,
-	});
-	if (!response) {
-		logError('Loading page: Failed');
-		throw 'Failed to load page!';
-	}
-
-	// If the response status code is not a 2xx success code
-	if (response.status() < 200 || response.status() > 299) {
-		logError(`Loading page: Failed. Status code: ${response.status()}`);
-		throw 'Failed to load page!';
-	}
-
-	// We see some run failures if we do not include a wait time after a page load
-	await page.waitForTimeout(3000);
-
-	log(`Loading page: Complete`);
-};
-
 /**
  * Checks that ads load correctly for the first time a user goes to
  * the site, with respect to and interaction with the CMP.
@@ -280,8 +242,6 @@ const pageLoadBlueprint = async function () {
 		screenshotOnStepSuccess: false,
 		screenshotOnStepFailure: true,
 	});
-
-	startTime = new Date().getTime();
 
 	// The query param "adtest=fixed-puppies-ci" is used to ensure that GAM provides us with an ad for our slot
 	await synthetics.executeStep('Test Front page', async function () {

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -8,6 +8,8 @@ const {
 	checkTopAdHasLoaded,
 	checkCMPIsOnPage,
 	checkCMPIsNotVisible,
+	loadPage,
+	reloadPage,
 } = require('./utils');
 
 const LOG_EVERY_REQUEST = false;
@@ -40,46 +42,6 @@ const interactWithCMP = async (page) => {
 	await frame.click(
 		'div.message-component.message-row > button.btn-primary.sp_choice_type_11',
 	);
-};
-
-const reloadPage = async (page) => {
-	log(`Reloading page: Start`);
-	const reloadResponse = await page.reload({
-		waitUntil: 'domcontentloaded',
-		timeout: 30000,
-	});
-	if (!reloadResponse) {
-		logError(`Reloading page: Failed`);
-		throw 'Failed to refresh page!';
-	}
-
-	// We see some run failures if we do not include a wait time after a page load
-	await page.waitForTimeout(3000);
-
-	log(`Reloading page: Complete`);
-};
-
-const loadPage = async (page, url) => {
-	log(`Loading page: Start`);
-	const response = await page.goto(url, {
-		waitUntil: 'domcontentloaded',
-		timeout: 30000,
-	});
-	if (!response) {
-		logError('Loading page: Failed');
-		throw 'Failed to load page!';
-	}
-
-	// If the response status code is not a 2xx success code
-	if (response.status() < 200 || response.status() > 299) {
-		logError(`Loading page: Failed. Status code: ${response.status()}`);
-		throw 'Failed to load page!';
-	}
-
-	// We see some run failures if we do not include a wait time after a page reload
-	await page.waitForTimeout(3000);
-
-	log(`Loading page: Complete`);
 };
 
 const getCurrentLocation = async (page) => {
@@ -316,8 +278,6 @@ const pageLoadBlueprint = async function () {
 		screenshotOnStepSuccess: false,
 		screenshotOnStepFailure: true,
 	});
-
-	startTime = new Date().getTime();
 
 	// The query param "adtest=fixed-puppies-ci" is used to ensure that GAM provides us with an ad for our slot
 	await synthetics.executeStep('Test Front page', async function () {

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -1,37 +1,9 @@
 const { URL } = require('url');
 const synthetics = require('Synthetics');
-const logger = require('SyntheticsLogger');
+const { log, logError, clearCookies, clearLocalStorage } = require('./utils');
 
 const LOG_EVERY_REQUEST = false;
 const LOG_EVERY_RESPONSE = false;
-
-let startTime = new Date().getTime();
-const getTimeSinceStart = () => new Date().getTime() - startTime;
-
-/**
- * We use custom log messages so that we can easily differentiate
- * between logs from this file and other logs in Cloudwatch.
- */
-const formatMessage = (message) =>
-	`GuCanaryRun. Time: ${getTimeSinceStart() / 1000}s. Message: ${message}`;
-
-const log = (message) => {
-	logger.info(formatMessage(message));
-};
-const logError = (message) => {
-	logger.error(formatMessage(message));
-};
-
-const clearCookies = async (page) => {
-	const allCookies = await page.cookies();
-	await page.deleteCookie(...allCookies);
-	log(`Cleared Cookies`);
-};
-
-const clearLocalStorage = async (page) => {
-	await page.evaluate(() => localStorage.clear());
-	log(`Cleared local storage`);
-};
 
 const checkTopAdHasLoaded = async (page) => {
 	log(`Waiting for ads to load: Start`);

--- a/src/cmp_tcfv2.js
+++ b/src/cmp_tcfv2.js
@@ -1,28 +1,17 @@
 const { URL } = require('url');
 const synthetics = require('Synthetics');
-const { log, logError, clearCookies, clearLocalStorage } = require('./utils');
+const {
+	log,
+	logError,
+	clearCookies,
+	clearLocalStorage,
+	checkTopAdHasLoaded,
+	checkCMPIsOnPage,
+	checkCMPIsNotVisible,
+} = require('./utils');
 
 const LOG_EVERY_REQUEST = false;
 const LOG_EVERY_RESPONSE = false;
-
-const checkTopAdHasLoaded = async (page) => {
-	log(`Waiting for ads to load: Start`);
-	try {
-		await page.waitForSelector(
-			'.ad-slot--top-above-nav .ad-slot__content iframe',
-			{ timeout: 30000 },
-		);
-	} catch (e) {
-		logError(`Failed to load top-above-nav ad: ${e.message}`);
-		await synthetics.takeScreenshot(
-			`${page}-page`,
-			'Failed to load top-above-nav ad',
-		);
-		throw new Error('top-above-nav ad did not load');
-	}
-
-	log(`Waiting for ads to load: Complete`);
-};
 
 const checkTopAdDidNotLoad = async (page) => {
 	log(`Checking ads do not load: Start`);
@@ -51,40 +40,6 @@ const interactWithCMP = async (page) => {
 	await frame.click(
 		'div.message-component.message-row > button.btn-primary.sp_choice_type_11',
 	);
-};
-
-const checkCMPIsOnPage = async (page) => {
-	log(`Waiting for CMP: Start`);
-	try {
-		await page.waitForSelector('[id*="sp_message_container"]');
-	} catch (e) {
-		logError(`Could not find CMP: ${e.message}`);
-		await synthetics.takeScreenshot(`${page}-page`, 'Could not find CMP');
-		throw new Error('top-above-nav ad did not load');
-	}
-
-	log(`Waiting for CMP: Finish`);
-};
-
-const checkCMPIsNotVisible = async (page) => {
-	log(`Checking CMP is Hidden: Start`);
-
-	const getSpMessageDisplayProperty = function () {
-		const element = document.querySelector('[id*="sp_message_container"]');
-		if (element) {
-			const computedStyle = window.getComputedStyle(element);
-			return computedStyle.getPropertyValue('display');
-		}
-	};
-
-	const display = await page.evaluate(getSpMessageDisplayProperty);
-
-	// Use `!=` rather than `!==` here because display is a DOMString type
-	if (display && display != 'none') {
-		throw Error('CMP still present on page');
-	}
-
-	log('CMP hidden or removed from page');
 };
 
 const reloadPage = async (page) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+const synthetics = require('Synthetics');
 const logger = require('SyntheticsLogger');
 
 /**
@@ -21,4 +22,57 @@ export const clearCookies = async (page) => {
 export const clearLocalStorage = async (page) => {
 	await page.evaluate(() => localStorage.clear());
 	log(`Cleared local storage`);
+};
+
+export const checkTopAdHasLoaded = async (page) => {
+	log(`Waiting for ads to load: Start`);
+	try {
+		await page.waitForSelector(
+			'.ad-slot--top-above-nav .ad-slot__content iframe',
+			{ timeout: 30000 },
+		);
+	} catch (e) {
+		logError(`Failed to load top-above-nav ad: ${e.message}`);
+		await synthetics.takeScreenshot(
+			`${page}-page`,
+			'Failed to load top-above-nav ad',
+		);
+		throw new Error('top-above-nav ad did not load');
+	}
+
+	log(`Waiting for ads to load: Complete`);
+};
+
+export const checkCMPIsOnPage = async (page) => {
+	log(`Waiting for CMP: Start`);
+	try {
+		await page.waitForSelector('[id*="sp_message_container"]');
+	} catch (e) {
+		logError(`Could not find CMP: ${e.message}`);
+		await synthetics.takeScreenshot(`${page}-page`, 'Could not find CMP');
+		throw new Error('top-above-nav ad did not load');
+	}
+
+	log(`Waiting for CMP: Finish`);
+};
+
+export const checkCMPIsNotVisible = async (page) => {
+	log(`Checking CMP is Hidden: Start`);
+
+	const getSpMessageDisplayProperty = function () {
+		const element = document.querySelector('[id*="sp_message_container"]');
+		if (element) {
+			const computedStyle = window.getComputedStyle(element);
+			return computedStyle.getPropertyValue('display');
+		}
+	};
+
+	const display = await page.evaluate(getSpMessageDisplayProperty);
+
+	// Use `!=` rather than `!==` here because display is a DOMString type
+	if (display && display != 'none') {
+		throw Error('CMP still present on page');
+	}
+
+	log('CMP hidden or removed from page');
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -76,3 +76,43 @@ export const checkCMPIsNotVisible = async (page) => {
 
 	log('CMP hidden or removed from page');
 };
+
+export const loadPage = async (page, url) => {
+	log(`Loading page: Start`);
+	const response = await page.goto(url, {
+		waitUntil: 'domcontentloaded',
+		timeout: 30000,
+	});
+	if (!response) {
+		logError('Loading page: Failed');
+		throw 'Failed to load page!';
+	}
+
+	// If the response status code is not a 2xx success code
+	if (response.status() < 200 || response.status() > 299) {
+		logError(`Loading page: Failed. Status code: ${response.status()}`);
+		throw 'Failed to load page!';
+	}
+
+	// We see some run failures if we do not include a wait time after a page load
+	await page.waitForTimeout(3000);
+
+	log(`Loading page: Complete`);
+};
+
+export const reloadPage = async (page) => {
+	log(`Reloading page: Start`);
+	const reloadResponse = await page.reload({
+		waitUntil: 'domcontentloaded',
+		timeout: 30000,
+	});
+	if (!reloadResponse) {
+		logError(`Reloading page: Failed`);
+		throw 'Failed to refresh page!';
+	}
+
+	// We see some run failures if we do not include a wait time after a page reload
+	await page.waitForTimeout(3000);
+
+	log(`Reloading page: Complete`);
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,24 @@
+const logger = require('SyntheticsLogger');
+
+/**
+ * We use custom log messages so that we can easily differentiate
+ * between logs from this file and other logs in Cloudwatch.
+ */
+export const log = (message) => {
+	logger.info(`GuCanaryRun. Message: ${message}`);
+};
+
+export const logError = (message) => {
+	logger.error(`GuCanaryRun. Message: ${message}`);
+};
+
+export const clearCookies = async (page) => {
+	const allCookies = await page.cookies();
+	await page.deleteCookie(...allCookies);
+	log(`Cleared Cookies`);
+};
+
+export const clearLocalStorage = async (page) => {
+	await page.evaluate(() => localStorage.clear());
+	log(`Cleared local storage`);
+};


### PR DESCRIPTION
## What are you changing?
Moves any functions which are repeated between files into a shared `utils` file.

Note that the `interactWithCMP` functions are region specific so I've left them for now.

## Why?
Reducing the amount that we're repeating ourselves. Also makes the functions much easier to update in future refactors and updates. I've been working on trying to update the runtime version and it'll be much easier with the functions definitions in one place!

Ideally in the future we could look at writing the code in typescript, but this makes life a little bit easier for now.